### PR TITLE
Support leaders config from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ x-env-defaults: &env
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}
   SENDGRID_DEV_TO: developer@endeavorb2b.com
   YARN_CACHE_FOLDER: /.yarn-cache
+  LEADERS_ALIAS: leaders-2020
 
 x-env-tauron: &env-tauron
   GRAPHQL_URI: ${GRAPHQL_URI-https://tauron.graphql.base.parameter1.com}

--- a/packages/common/graphql/fragments/content-company.js
+++ b/packages/common/graphql/fragments/content-company.js
@@ -1,5 +1,7 @@
 const gql = require('graphql-tag');
 
+const alias = process.env.LEADERS_ALIAS || 'leaders-2020';
+
 module.exports = gql`
 
 fragment WebsiteContentCompanyFragment on Content {
@@ -54,7 +56,7 @@ fragment WebsiteContentCompanyFragment on Content {
       alt
     }
 
-    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders-2021" })
+    isLeader: hasWebsiteSchedule(input: { sectionAlias: "${alias}" })
 
     contacts: publicContacts {
       edges {

--- a/packages/common/graphql/fragments/content-company.js
+++ b/packages/common/graphql/fragments/content-company.js
@@ -54,7 +54,7 @@ fragment WebsiteContentCompanyFragment on Content {
       alt
     }
 
-    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders-2020" })
+    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders-2021" })
 
     contacts: publicContacts {
       edges {

--- a/sites/automationworld.com/config/leaders.js
+++ b/sites/automationworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leadership in Automation',
-  alias: 'leaders-2021',
+  alias: process.env.LEADERS_ALIAS || 'leaders-2020',
   header: {
     imgSrc: 'https://img.automationworld.com/files/base/pmmi/all/leaders/aw-2020.png?h=90',
   },

--- a/sites/automationworld.com/config/leaders.js
+++ b/sites/automationworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leadership in Automation',
-  alias: 'leaders-2020',
+  alias: 'leaders-2021',
   header: {
     imgSrc: 'https://img.automationworld.com/files/base/pmmi/all/leaders/aw-2020.png?h=90',
   },

--- a/sites/healthcarepackaging.com/config/leaders.js
+++ b/sites/healthcarepackaging.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Premier Suppliers',
-  alias: 'leaders-2021',
+  alias: process.env.LEADERS_ALIAS || 'leaders-2020',
   header: {
     imgSrc: 'https://img.healthcarepackaging.com/files/base/pmmi/all/leaders/hcp.png',
   },

--- a/sites/healthcarepackaging.com/config/leaders.js
+++ b/sites/healthcarepackaging.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Premier Suppliers',
-  alias: 'leaders-2020',
+  alias: 'leaders-2021',
   header: {
     imgSrc: 'https://img.healthcarepackaging.com/files/base/pmmi/all/leaders/hcp.png',
   },

--- a/sites/oemmagazine.org/config/leaders.js
+++ b/sites/oemmagazine.org/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Partner Leaders',
-  alias: 'leaders-2020',
+  alias: 'leaders-2021',
   header: {
     imgSrc: 'https://img.oemmagazine.org/files/base/pmmi/all/leaders/oem-2020.png?h=90',
   },

--- a/sites/oemmagazine.org/config/leaders.js
+++ b/sites/oemmagazine.org/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Partner Leaders',
-  alias: 'leaders-2021',
+  alias: process.env.LEADERS_ALIAS || 'leaders-2020',
   header: {
     imgSrc: 'https://img.oemmagazine.org/files/base/pmmi/all/leaders/oem-2020.png?h=90',
   },

--- a/sites/packworld.com/config/leaders.js
+++ b/sites/packworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leaders in Packaging',
-  alias: 'leaders-2021',
+  alias: process.env.LEADERS_ALIAS || 'leaders-2020',
   header: {
     imgSrc: 'https://img.packworld.com/files/base/pmmi/all/leaders/pw-2020.png?h=90',
   },

--- a/sites/packworld.com/config/leaders.js
+++ b/sites/packworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leaders in Packaging',
-  alias: 'leaders-2020',
+  alias: 'leaders-2021',
   header: {
     imgSrc: 'https://img.packworld.com/files/base/pmmi/all/leaders/pw-2020.png?h=90',
   },

--- a/sites/profoodworld.com/config/leaders.js
+++ b/sites/profoodworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leaders in Processing',
-  alias: 'leaders-2020',
+  alias: 'leaders-2021',
   header: {
     imgSrc: 'https://img.profoodworld.com/files/base/pmmi/all/leaders/pfw-2020.png?h=90',
   },

--- a/sites/profoodworld.com/config/leaders.js
+++ b/sites/profoodworld.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Leaders in Processing',
-  alias: 'leaders-2021',
+  alias: process.env.LEADERS_ALIAS || 'leaders-2020',
   header: {
     imgSrc: 'https://img.profoodworld.com/files/base/pmmi/all/leaders/pfw-2020.png?h=90',
   },


### PR DESCRIPTION
Allows overriding the leadership alias via the env (to allow previewing on staging env)