### PR TITLE
Remove bad sort field from podcast queries

### DIFF
--- a/sites/automationworld.com/server/templates/published-content/podcasts.marko
+++ b/sites/automationworld.com/server/templates/published-content/podcasts.marko
@@ -36,8 +36,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -53,8 +51,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }

--- a/sites/cobotspot.packworld.com/server/templates/published-content/podcasts.marko
+++ b/sites/cobotspot.packworld.com/server/templates/published-content/podcasts.marko
@@ -35,8 +35,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -52,8 +50,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }

--- a/sites/healthcarepackaging.com/config/navigation.js
+++ b/sites/healthcarepackaging.com/config/navigation.js
@@ -44,6 +44,7 @@ module.exports = {
         { href: '/page/magazine', label: 'Magazine' },
         { href: '/leaders', label: 'Premier Suppliers' },
         { href: '/videos', label: 'Videos' },
+        { href: '/podcasts', label: 'Podcasts' },
         { href: 'https://www.pmmi.org/hall-of-fame', label: 'Hall of Fame', target: '_blank' },
         { href: '/webinars', label: 'Webinars' },
         // { href: '/page/digital-editions', label: 'Digital Editions' },

--- a/sites/healthcarepackaging.com/server/templates/published-content/podcasts.marko
+++ b/sites/healthcarepackaging.com/server/templates/published-content/podcasts.marko
@@ -36,8 +36,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -53,8 +51,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }

--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -42,6 +42,7 @@ module.exports = {
         { href: '/page/magazine', label: 'Magazine' },
         { href: '/leaders', label: 'Tech Trendsetters' },
         { href: '/videos', label: 'Videos' },
+        { href: '/podcasts', label: 'Podcasts' },
         // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },

--- a/sites/oemmagazine.org/server/templates/published-content/podcasts.marko
+++ b/sites/oemmagazine.org/server/templates/published-content/podcasts.marko
@@ -36,8 +36,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -53,8 +51,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }

--- a/sites/packworld.com/config/navigation.js
+++ b/sites/packworld.com/config/navigation.js
@@ -45,6 +45,7 @@ module.exports = {
         { href: '/page/magazine', label: 'Magazine' },
         { href: '/leaders', label: 'Leaders in Packaging' },
         { href: '/videos', label: 'Videos' },
+        { href: '/podcasts', label: 'Podcasts' },
         { href: '/page/packaging-associations', label: 'Packaging Associations' },
         { href: 'https://www.pmmi.org/hall-of-fame', label: 'Hall of Fame', target: '_blank' },
         { href: '/webinars', label: 'Webinars' },

--- a/sites/packworld.com/server/templates/published-content/podcasts.marko
+++ b/sites/packworld.com/server/templates/published-content/podcasts.marko
@@ -36,8 +36,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -53,8 +51,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }

--- a/sites/profoodworld.com/config/navigation.js
+++ b/sites/profoodworld.com/config/navigation.js
@@ -44,6 +44,7 @@ module.exports = {
         // { href: '/global-250', label: 'Global 250' },
         // { href: '/awards', label: 'Awards' },
         { href: '/videos', label: 'Videos' },
+        { href: '/podcasts', label: 'Podcasts' },
         { href: '/webinars', label: 'Webinars' },
         { href: 'https://www.opxleadershipnetwork.org', label: 'OpX Leadership Network', target: '_blank' },
         { href: '/page/awards-sema', label: 'Sustainability Awards' },

--- a/sites/profoodworld.com/server/templates/published-content/podcasts.marko
+++ b/sites/profoodworld.com/server/templates/published-content/podcasts.marko
@@ -36,8 +36,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         queryFragment,
       }
     >
@@ -53,8 +51,6 @@ $ const description = defaultDescription(title, config);
         withSite: false,
         contentTypes: ["Podcast"],
         limit: 18,
-        sortField: "startDate",
-        sortOrder: "desc",
         skip: 18,
       }
       page-input={ for: "published-content" }


### PR DESCRIPTION
[FD 529](https://parameter1.freshdesk.com/a/tickets/529) and [FD 562](https://parameter1.freshdesk.com/a/tickets/562)

- `startDate` isn't a field that is available on the Podcast type, causing pagination to fail when attempting to load a cursor (page 2). Remove sort
- Add podcast links to menu navs