### PR TITLE
Update to AW Leaders page information

### DIFF
--- a/sites/automationworld.com/server/templates/website-section/leaders.marko
+++ b/sites/automationworld.com/server/templates/website-section/leaders.marko
@@ -10,11 +10,10 @@ $ const {
 <shared-leaders-layout id=id alias=alias name=name page-node=pageNode>
   <@page-description>
     <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
-    <p>Voting for 2022 Honorees will begin in February.</p>
   </@page-description>
   <@page-body>
     <p>Recognize innovation, leadership and excellence among suppliers of automation software, technology and products.</p>
-    <p>Read the <em>Automation World</em> feature article to see all the <a href="/21112298">2020 First Team Honorees</a>.</p>
+    <p>Read the <em>Automation World</em> feature article to see all the <a href="/21232623">2021 First Team Honorees</a>.</p>
     <p><em>Thanks for your participation, which promotes excellence within the automation community!</em></p>
   </@page-body>
 </shared-leaders-layout>


### PR DESCRIPTION
Change to AW leaders page information (seconds screenshot shows where link navigates to)

<img width="1920" alt="Screen Shot 2021-05-13 at 4 12 12 PM" src="https://user-images.githubusercontent.com/46794001/118188623-4972dd00-b406-11eb-93e1-0ba9fc2c54f0.png">
<img width="1920" alt="Screen Shot 2021-05-13 at 4 12 21 PM" src="https://user-images.githubusercontent.com/46794001/118188637-4f68be00-b406-11eb-88fa-64b1f7f7d0d1.png">
