### PR TITLE
Create content attribution component with contact titles

### DIFF
--- a/packages/common/components/elements/attribution/components/authors.marko
+++ b/packages/common/components/elements/attribution/components/authors.marko
@@ -1,6 +1,6 @@
 <marko-web-content-authors|{ node }| block-name=input.blockName obj=input.content>
-<marko-web-block tag="span" class=`${input.blockName}__inner`>
-  <marko-web-content-name tag="span" obj=node link=true class=`${input.blockName}__name`/>
-  <marko-web-content-title tag="span" obj=node class=`${input.blockName}__title`/>
+  <marko-web-block tag="span" class=`${input.blockName}__inner`>
+    <marko-web-content-name tag="span" obj=node link=true class=`${input.blockName}__name`/>
+    <marko-web-content-title tag="span" obj=node class=`${input.blockName}__title`/>
   </marko-web-block>
 </marko-web-content-authors>

--- a/packages/common/components/elements/attribution/components/authors.marko
+++ b/packages/common/components/elements/attribution/components/authors.marko
@@ -1,0 +1,6 @@
+<marko-web-content-authors|{ node }| block-name=input.blockName obj=input.content>
+<marko-web-block tag="span" class=`${input.blockName}__inner`>
+  <marko-web-content-name tag="span" obj=node link=true class=`${input.blockName}__name`/>
+  <marko-web-content-title tag="span" obj=node class=`${input.blockName}__title`/>
+  </marko-web-block>
+</marko-web-content-authors>

--- a/packages/common/components/elements/attribution/components/byline.marko
+++ b/packages/common/components/elements/attribution/components/byline.marko
@@ -1,0 +1,1 @@
+<marko-web-content-byline block-name=input.blockName obj=input.content />

--- a/packages/common/components/elements/attribution/components/company.marko
+++ b/packages/common/components/elements/attribution/components/company.marko
@@ -1,0 +1,7 @@
+$ const { company } = input;
+
+<if(company && company.name)>
+  <div class=`${input.blockName}__content-company-name`>
+    <marko-web-content-name tag="span" block-name=input.blockName obj=company link=true />
+  </div>
+</if>

--- a/packages/common/components/elements/attribution/components/contributors.marko
+++ b/packages/common/components/elements/attribution/components/contributors.marko
@@ -1,0 +1,3 @@
+<marko-web-content-contributors|{ node }| block-name=input.blockName obj=input.content>
+  <marko-web-content-name tag="span" block-name=input.blockName obj=node link=true />
+</marko-web-content-contributors>

--- a/packages/common/components/elements/attribution/components/contributors.marko
+++ b/packages/common/components/elements/attribution/components/contributors.marko
@@ -1,3 +1,6 @@
 <marko-web-content-contributors|{ node }| block-name=input.blockName obj=input.content>
-  <marko-web-content-name tag="span" block-name=input.blockName obj=node link=true />
+  <marko-web-block tag="span" class=`${input.blockName}__inner`>
+    <marko-web-content-name tag="span" obj=node link=true class=`${input.blockName}__name`/>
+    <marko-web-content-title tag="span" obj=node class=`${input.blockName}__title`/>
+  </marko-web-block>
 </marko-web-content-contributors>

--- a/packages/common/components/elements/attribution/components/photographers.marko
+++ b/packages/common/components/elements/attribution/components/photographers.marko
@@ -1,0 +1,3 @@
+<marko-web-content-photographers|{ node }| block-name=input.blockName obj=input.content>
+  <marko-web-content-name tag="span" block-name=input.blockName obj=node link=true />
+</marko-web-content-photographers>

--- a/packages/common/components/elements/attribution/components/photographers.marko
+++ b/packages/common/components/elements/attribution/components/photographers.marko
@@ -1,3 +1,6 @@
 <marko-web-content-photographers|{ node }| block-name=input.blockName obj=input.content>
-  <marko-web-content-name tag="span" block-name=input.blockName obj=node link=true />
+  <marko-web-block tag="span" class=`${input.blockName}__inner`>
+    <marko-web-content-name tag="span" obj=node link=true class=`${input.blockName}__name`/>
+    <marko-web-content-title tag="span" obj=node class=`${input.blockName}__title`/>
+  </marko-web-block>
 </marko-web-content-photographers>

--- a/packages/common/components/elements/attribution/components/source.marko
+++ b/packages/common/components/elements/attribution/components/source.marko
@@ -1,0 +1,1 @@
+<marko-web-content-source block-name=input.blockName obj=input.content />

--- a/packages/common/components/elements/attribution/components/sponsors.marko
+++ b/packages/common/components/elements/attribution/components/sponsors.marko
@@ -1,0 +1,3 @@
+<marko-web-content-sponsors|{ node }| block-name=input.blockName obj=input.content>
+  <marko-web-content-name tag="span" block-name=input.blockName obj=node link=true />
+</marko-web-content-sponsors>

--- a/packages/common/components/elements/attribution/index.marko
+++ b/packages/common/components/elements/attribution/index.marko
@@ -1,0 +1,34 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import authors from "./components/authors";
+import byline from "./components/byline";
+import company from "./components/company";
+import contributors from "./components/contributors";
+import photographers from "./components/photographers";
+import source from "./components/source";
+import sponsors from "./components/sponsors";
+
+$ const content = getAsObject(input, "obj");
+$ const elements = Array.isArray(input.elements) ? input.elements : ["byline", "authors", "contributors", "photographers", "source", "company", "sponsors"];
+
+<default-theme-page-attribution|{ blockName }|
+  tag=input.tag
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  $ const elementMap = {
+    authors: { component: authors, input: { blockName, content } },
+    byline: { component: byline, input: { blockName, content } },
+    company: { component: company, input: { blockName, company: getAsObject(content, "company") } },
+    contributors: { component: contributors, input: { blockName, content } },
+    photographers: { component: photographers, input: { blockName, content } },
+    source: { component: source, input: { blockName, content } },
+    sponsors: { component: sponsors, input: { blockName, content } },
+  };
+  <for|elementName| of=elements>
+    $ const element = elementMap[elementName];
+    <if(element)>
+      <${element.component} ...element.input />
+    </if>
+  </for>
+</default-theme-page-attribution>

--- a/packages/common/components/elements/attribution/marko.json
+++ b/packages/common/components/elements/attribution/marko.json
@@ -1,0 +1,17 @@
+{
+  "<common-content-attribution-element>": {
+    "template": "./index.marko",
+    "@obj": "object",
+    "@elements": {
+      "type": "array",
+      "default-value": ["byline", "authors", "contributors", "photographers", "source", "company", "sponsors"]
+    },
+    "@tag": {
+      "type": "string",
+      "default-value": "div"
+    },
+    "@class": "string",
+    "@modifiers": "@array",
+    "@attrs": "object"
+  }
+}

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -16,5 +16,8 @@
       "template": "./supplier-disclaimer.marko",
       "@obj": "object"
     }
-  }
+  },
+  "taglib-imports": [
+    "./attribution/marko.json"
+  ]
 }

--- a/packages/common/scss/common.scss
+++ b/packages/common/scss/common.scss
@@ -34,6 +34,7 @@ $theme-site-header-breakpoints: map-merge(
 @import "./contact-us-form"; // @todo this should be remove once contact us is in core
 @import "./company-page";
 @import "./leaders-index-page";
+@import "./content-page";
 
 .leaders {
   @include border-radius($theme-card-border-radius);

--- a/packages/common/scss/content-page.scss
+++ b/packages/common/scss/content-page.scss
@@ -1,0 +1,18 @@
+.page-attribution {
+  &
+  &__inner {
+    &::before {
+      margin-right: .25rem;
+      font-weight: 400;
+      content: "—";
+    }
+  }
+  &__title {
+    &::before {
+      content: ", ";
+    }
+    &::after {
+      content: " ";
+    }
+  }
+}

--- a/packages/common/scss/content-page.scss
+++ b/packages/common/scss/content-page.scss
@@ -1,5 +1,4 @@
 .page-attribution {
-  &
   &__inner {
     &::before {
       margin-right: .25rem;

--- a/packages/shared/graphql/fragments/content-page.js
+++ b/packages/shared/graphql/fragments/content-page.js
@@ -142,6 +142,7 @@ fragment ContentPageFragment on Content {
         node {
           id
           name
+          title
           type
           siteContext {
             path
@@ -154,6 +155,7 @@ fragment ContentPageFragment on Content {
         node {
           id
           name
+          title
           type
           siteContext {
             path

--- a/packages/shared/graphql/fragments/content-page.js
+++ b/packages/shared/graphql/fragments/content-page.js
@@ -168,6 +168,7 @@ fragment ContentPageFragment on Content {
         node {
           id
           name
+          title
           type
           siteContext {
             path

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -45,7 +45,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <if(content.type !== "contact")>
-                <default-theme-content-attribution obj=content />
+                <common-content-attribution-element obj=content />
               </if>
               <default-theme-page-dates|{ blockName }|>
                 <if(content.type === "event")>

--- a/packages/shared/templates/content/podcast.marko
+++ b/packages/shared/templates/content/podcast.marko
@@ -32,6 +32,7 @@ $ const { id, type, pageNode } = data;
         <@section>
           <div class="row">
             <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <common-content-attribution-element obj=content />
               <default-theme-content-contact-details obj=content />
               <shared-content-body-with-tracking block-name=blockName content=content />
               <marko-web-content-sidebars block-name=blockName obj=content />


### PR DESCRIPTION
<img width="1919" alt="Screen Shot 2021-05-17 at 3 46 51 PM" src="https://user-images.githubusercontent.com/46794001/118554708-6c173580-b727-11eb-85ef-6b950ad9fc69.png">
<img width="1920" alt="Screen Shot 2021-05-17 at 3 47 25 PM" src="https://user-images.githubusercontent.com/46794001/118554729-72a5ad00-b727-11eb-80a8-ab78d1e2b254.png">
<img width="1920" alt="Screen Shot 2021-05-17 at 3 47 32 PM" src="https://user-images.githubusercontent.com/46794001/118554773-7b967e80-b727-11eb-9bcb-e7f4af005f63.png">
<img width="1917" alt="Screen Shot 2021-05-17 at 3 48 04 PM" src="https://user-images.githubusercontent.com/46794001/118554778-7d604200-b727-11eb-9d36-cd8d0559fe4c.png">
<img width="1918" alt="Screen Shot 2021-05-17 at 3 48 24 PM" src="https://user-images.githubusercontent.com/46794001/118554782-7e916f00-b727-11eb-8007-54807fbc1131.png">

Change to title attributions on all content in PMMI sites.