### PR TITLE
Update nav and menu to include downloads

### DIFF
--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -87,7 +87,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
-              <shared-inquiry-block content=content lang=lang/>
+              <shared-inquiry-block content=content lang=lang />
 
               <marko-web-gam-display-ad id="gpt-ad-imu1" />
 

--- a/sites/mundopmmi.com/config/navigation.js
+++ b/sites/mundopmmi.com/config/navigation.js
@@ -10,6 +10,7 @@ module.exports = {
       { href: '/empaque', label: 'Empaque' },
       { href: '/procesamiento', label: 'Procesamiento' },
       { href: '/eventos', label: 'Eventos' },
+      { href: '/downloads', label: 'Recursos Digitales' },
     ],
   },
   tertiary: {
@@ -42,6 +43,7 @@ module.exports = {
         { href: '/eventos', label: 'Eventos' },
         { href: '/leaders', label: 'Líderes' },
         { href: '/videos', label: 'Vídeos' },
+        { href: '/downloads', label: 'Recursos Digitales' },
       ],
     },
     {


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-07-14 at 10 11 57 AM" src="https://user-images.githubusercontent.com/46794001/125646544-171eeacc-e68a-4b25-92b4-e55d2094630c.png">
(This also includes a change to fix the syntax of a marko template that missed a previous PR a while back)