### PR TITLE
Correct query for Webinars page

### DIFF
--- a/packages/shared/templates/published-content/webinars.marko
+++ b/packages/shared/templates/published-content/webinars.marko
@@ -33,7 +33,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-page-wrapper>
 
     <marko-web-query|{ nodes }|
-      name="website-scheduled-content"
+      name="all-published-content"
       params={ includeContentTypes:["Webinar"], limit: 18, sortField: "startDate", sortOrder: "desc", queryFragment }
     >
       <shared-content-list-flow nodes=nodes />
@@ -43,7 +43,7 @@ $ const description = defaultDescription(title, config);
     <marko-web-load-more
       component-name="content-list-flow"
       fragment-name="content-list"
-      query-name="website-scheduled-content"
+      query-name="all-published-content"
       query-params={ includeContentTypes:["Webinar"], limit: 18, sortField: "startDate", sortOrder: "desc", skip: 18 }
       page-input={ for: "published-content" }
     />


### PR DESCRIPTION
<img width="1918" alt="Screen Shot 2021-07-20 at 12 17 40 PM" src="https://user-images.githubusercontent.com/46794001/126367745-24e79764-838e-4e85-985d-2990671e4309.png">
