### PR TITLE
Add IdentityX gated content, gated print content & Omeda rapidIdentityX component.  

### DIFF
--- a/packages/shared/components/blocks/content-page/gate.marko
+++ b/packages/shared/components/blocks/content-page/gate.marko
@@ -1,0 +1,53 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue  from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { config } = out.global;
+
+$ const blockName = "content-page-gate";
+$ const {
+  canAccess,
+  isLoggedIn,
+  hasRequiredAccessLevel,
+  requiresAccessLevel,
+  requiresUserInput,
+} = input;
+$ const messages = getAsObject(input, "messages");
+$ const title = defaultValue(input.title, "Log in to view the full article");
+$ const userInputTitle = defaultValue(input.userInputTitle, "Complete your profile to view the full article");
+
+<marko-web-block name=blockName>
+  <if(!canAccess)>
+    <marko-web-element tag="h5" name="title" block-name=blockName>
+      ${title}
+    </marko-web-element>
+    <if(isLoggedIn && !hasRequiredAccessLevel)>
+      <marko-web-element name="body" block-name=blockName>
+        $!{messages.loggedInNoAccess}
+      </marko-web-element>
+    </if>
+    <else>
+      <marko-web-element name="body" block-name=blockName>
+        <if(!requiresAccessLevel)>
+          $!{messages.loggedOutNoAccess}
+        </if>
+        <else>
+          <p>Register on ${config.website("name")} and gain access to premium content, including this article and much more.</p>
+          <p>To log in or register, begin by entering your email address below.</p>
+        </else>
+      </marko-web-element>
+
+      <marko-web-element name="form-wrapper" block-name=blockName>
+        <marko-web-identity-x-form-register />
+      </marko-web-element>
+    </else>
+  </if>
+  <else-if(isLoggedIn && requiresUserInput)>
+    <marko-web-element tag="h5" name="title" block-name=blockName>
+      ${userInputTitle}
+    </marko-web-element>
+
+    <marko-web-element name="form-wrapper" block-name=blockName>
+      <marko-web-identity-x-form-profile reload-page-on-submit=true />
+    </marko-web-element>
+  </else-if>
+</marko-web-block>

--- a/packages/shared/components/blocks/content-page/marko.json
+++ b/packages/shared/components/blocks/content-page/marko.json
@@ -1,0 +1,13 @@
+{
+  "<shared-content-page-gate>": {
+    "template": "./gate.marko",
+    "@can-access": "boolean",
+    "@is-logged-in": "boolean",
+    "@has-required-access-level": "boolean",
+    "@requires-access-level": "boolean",
+    "@requires-user-input": "boolean",
+    "@messages": "object",
+    "@title": "string",
+    "@user-input-title": "string"
+  }
+}

--- a/packages/shared/components/blocks/marko.json
+++ b/packages/shared/components/blocks/marko.json
@@ -1,4 +1,7 @@
 {
+  "taglib-imports": [
+    "./content-page/marko.json"
+  ],
   "<shared-content-body-with-tracking>": {
     "template": "./content-body-with-tracking.marko",
     "@content": {

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -88,5 +88,6 @@ $ const {
   </@below-container>
   <@below-wrapper>
     <marko-web-deferred-script-loader-load />
+    <marko-web-browser-component name="OmedaRapidIdentityX" />
   </@below-wrapper>
 </marko-web-document>

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -22,7 +22,7 @@ $ const {
       on="load"
       request-frame=true
       target-tag="body"
-      identity-query-builder=`var id = query.oly_enc_id; if (id) { return 'omeda.${omedaConfig.brandKey}.customer*' + id + '~encoded'; };`;
+      identity-query-builder=`var id = query.oly_enc_id; if (id) { return 'omeda.${omedaConfig.brandKey}.customer*' + id + '~encoded'; };`
     />
 
     <!-- init gam -->

--- a/packages/shared/graphql/fragments/content-page.js
+++ b/packages/shared/graphql/fragments/content-page.js
@@ -11,11 +11,16 @@ fragment ContentPageFragment on Content {
   body
   status
   published
+  siteContext {
+    path
+    canonicalUrl
+  }
   company {
     id
     name
     siteContext {
       path
+      canonicalUrl
     }
   }
   taxonomy(input: { type: Category }) {
@@ -77,6 +82,10 @@ fragment ContentPageFragment on Content {
   gating {
     surveyType
     surveyId
+  }
+  userRegistration {
+    isRequired
+    accessLevels
   }
   ... on ContentVideo {
     embedCode

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,7 @@
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/omeda-graphql-client-express": "^0.2.3",
     "@pmmi-media-group/package-common": "^2.2.9",
+    "cheerio": "^1.0.0-rc.3",
     "graphql": "^14.5.4",
     "graphql-tag": "^2.10.1",
     "newrelic": "^6.4.1"

--- a/packages/shared/routes/index.js
+++ b/packages/shared/routes/index.js
@@ -2,6 +2,7 @@ const identityX = require('./identity-x');
 const inquiryHandler = require('../inquiry-handler');
 const dynamicPages = require('./dynamic-page');
 const magazine = require('./magazine');
+const printContent = require('./print-content');
 const publishedContent = require('./published-content');
 const search = require('./search');
 const subscribe = require('./subscribe');
@@ -18,6 +19,9 @@ module.exports = (app) => {
 
   // Dynamic Pages
   dynamicPages(app);
+
+  // Print Content Pages
+  printContent(app);
 
   // Published Content Pages
   publishedContent(app);

--- a/packages/shared/routes/print-content.js
+++ b/packages/shared/routes/print-content.js
@@ -1,0 +1,11 @@
+const { withContent } = require('@parameter1/base-cms-marko-web/middleware');
+const print = require('../templates/content/print');
+const queryFragment = require('../graphql/fragments/content-page');
+
+module.exports = (app) => {
+  app.get('/print/content/:id(\\d{8})', withContent({
+    template: print,
+    queryFragment,
+    redirectOnPathMismatch: false,
+  }));
+};

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -1,6 +1,7 @@
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
 import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-list";
+import getContentPreview from "../../utils/get-content-preview";
 
 $ const { site, GAM } = out.global;
 $ const { id, type, pageNode } = data;
@@ -68,8 +69,35 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
             <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
               <shared-content-media-block content=content blockName=blockName />
               <default-theme-content-contact-details obj=content />
-              <shared-content-body-with-tracking block-name=blockName content=content />
-              <marko-web-content-sidebars block-name=blockName obj=content />
+
+              $ const requiresRegistration = get(content, "userRegistration.isRequired");
+              $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
+              <marko-web-identity-x-access|context|
+                enabled=requiresRegistration
+                required-access-level-ids=accessLevels
+              >
+                <if(!context.canAccess || context.requiresUserInput)>
+                  $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+                  <marko-web-content-body block-name=blockName obj={ body } />
+
+                  <div class="content-page-preview-overlay" />
+                  <shared-content-page-gate
+                    can-access=context.canAccess
+                    is-logged-in=context.isLoggedIn
+                    has-required-access-level=context.hasRequiredAccessLevel
+                    requires-access-level=context.requiresAccessLevel
+                    requires-user-input=context.requiresUserInput
+                    messages=context.messages
+                  />
+                </if>
+                <else>
+                  <shared-content-body-with-tracking block-name=blockName content=content />
+                  <marko-web-content-sidebars block-name=blockName obj=content />
+                  <if(["article", "blog", "media-gallery", "news", "podcast", "press-release", "product", "video", "webinar"].includes(content.type))>
+                    <common-featured-companies content=content />
+                  </if>
+                </else>
+
               <if(type === "document" || type === "whitepaper")>
                 <default-theme-content-download obj=content>
                   <@wufoo user-name=site.get("wufoo.userName") />
@@ -77,13 +105,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 </default-theme-content-download>
               </if>
 
-              <if(["article", "blog", "media-gallery", "news", "podcast", "press-release", "product", "video", "webinar"].includes(content.type))>
-                <common-featured-companies content=content />
-              </if>
-
               <!-- Div for BI Library -->
               <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-bilibrary" class="mt-3" />
-
+              </marko-web-identity-x-access>
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">

--- a/packages/shared/templates/content/print.marko
+++ b/packages/shared/templates/content/print.marko
@@ -29,7 +29,8 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
     <div class="container p-5 bg-white">
       <div class="row mb-block">
         <div class="col">
-          $ const logoSrc = buildImgixUrl(site.get("logos.navbar.src"), { h: 100 });
+          $ const src = site.get("logos.printContent.src") ? site.get("logos.printContent.src") : site.get("logos.navbar.src");
+          $ const logoSrc = buildImgixUrl(src, { h: 100 });
           <if(logoSrc)>
             <marko-web-img
               link={ href: "/" }

--- a/packages/shared/templates/content/print.marko
+++ b/packages/shared/templates/content/print.marko
@@ -1,0 +1,184 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+import imageHeight from "@parameter1/base-cms-marko-web/components/node/utils/image-height";
+import getContentPreview from "../../utils/get-content-preview";
+
+$ const { id, type, pageNode } = data;
+$ const { site, config, req } = out.global;
+
+$ const cardBlock = "content-page-card";
+$ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
+
+<marko-web-document>
+  <@head>
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <marko-web-content-page-metadata id=id />
+
+    <marko-web-gtm-init container-id=site.get("gtm.containerId") />
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <!-- Override canonical path to print path -->
+      $ const ctx = { ...context, canonical_path: req.path };
+      <marko-web-gtm-push data=ctx />
+    </marko-web-gtm-content-context>
+    <marko-web-gtm-start />
+  </@head>
+  <@above-container>
+    <div class="container p-5 bg-white">
+      <div class="row mb-block">
+        <div class="col">
+          $ const logoSrc = buildImgixUrl(site.get("logos.navbar.src"), { h: 100 });
+          <if(logoSrc)>
+            <marko-web-img
+              link={ href: "/" }
+              src=logoSrc
+              srcset=[`${buildImgixUrl(logoSrc, { dpr: 2 })} 2x`]
+              lazyload=false
+              alt=config.website("name")
+              attrs={ style: "max-width: 40%;" }
+            />
+          </if>
+        </div>
+      </div>
+
+      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+        $ const primarySection = getAsObject(content, "primarySection");
+
+        $ const primaryImage = getAsObject(content, "primaryImage");
+        $ const hasImage = Boolean(primaryImage.src);
+        $ const imgWidth = 768;
+        $ const imgHeight = imageHeight(imgWidth, "16:9");
+
+        $ const displayPrimaryImage = hasImage && !primaryImage.isLogo;
+
+        $ const src = buildImgixUrl(primaryImage.src, { w: imgWidth, h: imgHeight, fit: "crop" });
+        $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
+
+        $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+
+        <default-theme-page-contents|{ blockName: contentsBlock }|>
+          <if(displayPrimaryImage)>
+            <div class="mb-block">
+              <marko-web-node-element name="header" block-name=cardBlock>
+                <marko-web-node-element name="header-image-wrapper" block-name=cardBlock>
+                  <marko-web-node-element
+                    name="image-inner-wrapper"
+                    block-name=cardBlock
+                    modifiers=["16by9"]
+                  >
+                    <marko-web-img
+                      src=src
+                      srcset=srcset
+                      alt=primaryImage.alt
+                      class=`${cardBlock}__image mb-block`
+                      lazyload=false
+                    />
+                    <marko-web-image-credit block-name=cardBlock obj=primaryImage />
+                  </marko-web-node-element>
+                </marko-web-node-element>
+              </marko-web-node-element>
+            </div>
+          </if>
+
+          <if(isSponsored)>
+            <div class=`${cardBlock}__sponsored-content`>Sponsored Content</div>
+          </if>
+          <default-theme-website-section-breadcrumbs
+            section=primarySection
+            display-home=false
+            modifiers=[cardBlock]
+          />
+          <marko-web-content-name
+            tag="h1"
+            block-name=cardBlock
+            obj=content
+          />
+          <marko-web-content-teaser
+            tag="p"
+            block-name=cardBlock
+            obj=content
+          />
+          $ const requiresRegistration = get(content, "userRegistration.isRequired");
+          $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
+          <marko-web-identity-x-access|context|
+            enabled=requiresRegistration
+            required-access-level-ids=accessLevels
+          >
+            <if(!context.canAccess || context.requiresUserInput)>
+              $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+              <marko-web-content-body block-name=contentsBlock obj={ body } />
+
+              <div class="content-page-preview-overlay" />
+              <shared-content-page-gate
+                can-access=context.canAccess
+                is-logged-in=context.isLoggedIn
+                has-required-access-level=context.hasRequiredAccessLevel
+                requires-access-level=context.requiresAccessLevel
+                requires-user-input=context.requiresUserInput
+                messages="Login to print the full article."
+              />
+            </if>
+            <else>
+              <if(primaryImage.isLogo)>
+                <marko-web-page-image
+                  obj=primaryImage
+                  fluid=false
+                  width=250
+                />
+              </if>
+
+              <if(type !== "contact")>
+                <default-theme-content-attribution obj=content />
+                <default-theme-page-dates|{ blockName }|>
+                  <if(type === "event")>
+                    <marko-web-content-start-date block-name=blockName obj=content />
+                    <marko-web-content-end-date block-name=blockName obj=content />
+                  </if>
+                  <if(type === "webinar")>
+                    <marko-web-content-start-date block-name=blockName obj=content />
+                  </if>
+                  <if(displayPublishedDate)>
+                    <marko-web-content-published block-name=blockName obj=content />
+                  </if>
+                </default-theme-page-dates>
+              </if>
+
+              <hr>
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=contentsBlock obj=content>
+                <@embed-options lazyload-images=false />
+              </marko-web-content-body>
+              <marko-web-content-sidebars block-name=contentsBlock obj=content />
+
+              <hr>
+              <div>
+                <strong>Source URL:</strong> ${content.siteContext.canonicalUrl}
+              </div>
+            </else>
+          </marko-web-identity-x-access>
+        </default-theme-page-contents>
+      </marko-web-resolve-page>
+    </div>
+  </@above-container>
+  <@below-container>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const requiresRegistration = get(content, "userRegistration.isRequired");
+      $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
+      <marko-web-identity-x-access|context|
+        enabled=requiresRegistration
+        required-access-level-ids=accessLevels
+      >
+        <if(context.canAccess)>
+          <script>
+            (function() {
+              window.print();
+            })(window);
+          </script>
+        </if>
+      </marko-web-identity-x-access>
+    </marko-web-resolve-page>
+  </@below-container>
+</marko-web-document>

--- a/packages/shared/utils/get-content-preview.js
+++ b/packages/shared/utils/get-content-preview.js
@@ -1,0 +1,7 @@
+const cheerio = require('cheerio');
+
+module.exports = ({ body, selector } = {}) => {
+  if (!body) return '';
+  const $ = cheerio.load(body);
+  return $.html(selector);
+};

--- a/sites/automationworld.com/config/site.js
+++ b/sites/automationworld.com/config/site.js
@@ -29,6 +29,12 @@ module.exports = {
         'https://img.automationworld.com/files/base/pmmi/aw/aw_logo.png?h=120&auto=format,compress&q=70 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/aw_logo_black.png?h=45&auto=format,compress&q=70',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/aw_logo_black.png?h=90&auto=format,compress&q=70 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'facebook', href: 'https://www.facebook.com/AutomationWorldMag' },

--- a/sites/healthcarepackaging.com/config/site.js
+++ b/sites/healthcarepackaging.com/config/site.js
@@ -29,6 +29,12 @@ module.exports = {
         'https://img.healthcarepackaging.com/files/base/pmmi/hcp/hcp_logo.png?h=120&auto=format,compress&q=70 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.healthcarepackaging.com/files/base/pmmi/hcp/hcp_logo_black.png?h=45&auto=format,compress&q=70',
+      srcset: [
+        'https://img.healthcarepackaging.com/files/base/pmmi/hcp/hcp_logo_black.png?h=90&auto=format,compress&q=70 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'facebook', href: 'https://www.facebook.com/HealthcarePackaging' },

--- a/sites/mundopmmi.com/config/site.js
+++ b/sites/mundopmmi.com/config/site.js
@@ -30,6 +30,12 @@ module.exports = {
         'https://img.mundopmmi.com/files/base/pmmi/mundo/footerLogos_white.png?h=120 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.mundopmmi.com/files/base/pmmi/mundo/MundoPMMI_logo_black_notag.png?h=80',
+      srcset: [
+        'https://img.mundopmmi.com/files/base/pmmi/mundo/MundoPMMI_logo_black_notag.png?h=160 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'linkedin', href: 'https://www.linkedin.com/showcase/mundo-pmmi' },

--- a/sites/oemmagazine.org/config/site.js
+++ b/sites/oemmagazine.org/config/site.js
@@ -29,6 +29,12 @@ module.exports = {
         'https://img.oemmagazine.org/files/base/pmmi/oem/oem_logo.png?h=120&auto=format,compress&q=70 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.oemmagazine.org/files/base/pmmi/oem/oem_logo_black.png?h=45&auto=format,compress&q=70',
+      srcset: [
+        'https://img.oemmagazine.org/files/base/pmmi/oem/oem_logo_black.png?h=90&auto=format,compress&q=70 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'twitter', href: 'https://twitter.com/oemmagazine' },

--- a/sites/packworld.com/config/site.js
+++ b/sites/packworld.com/config/site.js
@@ -29,6 +29,12 @@ module.exports = {
         'https://img.packworld.com/files/base/pmmi/pw/pw_logo.png?h=120&auto=format,compress&q=70 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.packworld.com/files/base/pmmi/pw/pw_logo_black.png?h=45&auto=format,compress&q=70',
+      srcset: [
+        'https://img.packworld.com/files/base/pmmi/pw/pw_logo_black.png?h=90&auto=format,compress&q=70 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'facebook', href: 'https://www.facebook.com/PackagingWorld' },

--- a/sites/profoodworld.com/config/site.js
+++ b/sites/profoodworld.com/config/site.js
@@ -29,6 +29,12 @@ module.exports = {
         'https://img.profoodworld.com/files/base/pmmi/pfw/pfw_logo.png?h=120&auto=format,compress&q=70 2x',
       ],
     },
+    printContent: {
+      src: 'https://img.profoodworld.com/files/base/pmmi/pfw/pfw_logo_black.png?h=45&auto=format,compress&q=70',
+      srcset: [
+        'https://img.profoodworld.com/files/base/pmmi/pfw/pfw_logo_black.png?h=90&auto=format,compress&q=70 2x',
+      ],
+    },
   },
   socialMediaLinks: [
     { provider: 'twitter', href: 'https://twitter.com/ProFoodWorld' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4146,6 +4146,17 @@ cheerio-select-tmp@^0.1.0:
     domhandler "^4.0.0"
     domutils "^2.4.4"
 
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
 cheerio@1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -4157,6 +4168,19 @@ cheerio@1.0.0-rc.2:
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
     parse5 "^3.0.1"
+
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 cheerio@^1.0.0-rc.5:
   version "1.0.0-rc.5"
@@ -4840,6 +4864,17 @@ css-select@^3.1.2:
     domutils "^2.4.3"
     nth-check "^2.0.0"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -4867,6 +4902,11 @@ css-what@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-4.0.0.tgz#35e73761cab2eeb3d3661126b23d7aa0e8432233"
   integrity sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
+
+css-what@^5.0.0, css-what@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
 css@2.X, css@^2.2.1:
   version "2.2.4"
@@ -5271,6 +5311,15 @@ dom-serializer@^1.0.1, dom-serializer@~1.2.0:
     domhandler "^4.0.0"
     entities "^2.0.0"
 
+dom-serializer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
 dom-serializer@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -5299,6 +5348,11 @@ domelementtype@^2.1.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
   integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
+domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
@@ -5312,6 +5366,13 @@ domhandler@^4.0.0:
   integrity sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==
   dependencies:
     domelementtype "^2.1.0"
+
+domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -5337,6 +5398,15 @@ domutils@^2.4.3, domutils@^2.4.4:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
+
+domutils@^2.5.2, domutils@^2.6.0, domutils@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
+  integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dont-sniff-mimetype@1.1.0:
   version "1.1.0"
@@ -7224,6 +7294,16 @@ htmlparser2@^6.0.0:
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
     domutils "^2.4.4"
+    entities "^2.0.0"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
     entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
@@ -9936,7 +10016,7 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parse5-htmlparser2-tree-adapter@^6.0.0:
+parse5-htmlparser2-tree-adapter@^6.0.0, parse5-htmlparser2-tree-adapter@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
   integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
@@ -12719,6 +12799,11 @@ tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Currently Gated on Packworld.com 
 - /machinery/primary-packaging/article/13325946/superior-takes-control-in-small-coffee-packs

Standard landing page gated:
<img width="1226" alt="Screen Shot 2021-07-27 at 10 17 22 AM" src="https://user-images.githubusercontent.com/3845869/127180668-9b714816-86ed-48ed-87ed-1dad13adb53d.png">

/print/content/${id}. gated content(also disables auto print trigger):
![gatedPrint](https://user-images.githubusercontent.com/3845869/127180808-12eb7c4c-0107-4a58-a10c-207cbf6a81fb.jpeg)
