### PR TITLE
Add google sheets api route to PFW to use api key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ x-env-defaults: &env
   # @todo the recaptcha values should be removed (?) once contact-us is moved to core.
   RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY-(unset)}
   RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY-(unset)}
+  GLOBAL_50_250_DOCS_API_KEY: ${GLOBAL_50_250_DOCS_API_KEY-(unset)}
   # @todo the sendgrid values should be removed once the @parameter1/base-cms-mailer service is created.
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}
   SENDGRID_DEV_TO: ${SENDGRID_DEV_TO-support@parameter1.com}

--- a/sites/profoodworld.com/env.js
+++ b/sites/profoodworld.com/env.js
@@ -1,0 +1,8 @@
+const { cleanEnv, validators } = require('@parameter1/base-cms-env');
+
+const { nonemptystr } = validators;
+
+// @todo This should be removed once contact us is moved to core and the mailer service is created.
+module.exports = cleanEnv(process.env, {
+  GLOBAL_50_250_DOCS_API_KEY: nonemptystr({ desc: 'The google doc api secret key.' }),
+});

--- a/sites/profoodworld.com/package.json
+++ b/sites/profoodworld.com/package.json
@@ -15,6 +15,7 @@
     "test": "yarn lint && yarn compile && yarn build"
   },
   "dependencies": {
+    "@parameter1/base-cms-env": "^2.0.0",
     "@parameter1/base-cms-marko-core": "^2.37.2",
     "@parameter1/base-cms-marko-web": "^2.38.0",
     "@parameter1/base-cms-marko-web-gam": "^2.22.2",
@@ -32,6 +33,7 @@
     "@pmmi-media-group/package-common": "^2.2.11",
     "@pmmi-media-group/package-shared": "^2.2.11",
     "graphql": "^14.5.4",
-    "graphql-tag": "^2.10.1"
+    "graphql-tag": "^2.10.1",
+    "node-fetch": "^2.6.0"
   }
 }

--- a/sites/profoodworld.com/server/routes/global-50-250-sheets.js
+++ b/sites/profoodworld.com/server/routes/global-50-250-sheets.js
@@ -1,0 +1,17 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const fetch = require('node-fetch');
+const { GLOBAL_50_250_DOCS_API_KEY } = require('../../env');
+
+module.exports = (app) => {
+  app.use('/__global-50-250-sheets', asyncRoute(async (req, res) => {
+    const { src } = req.query;
+    const url = `${src}?key=${GLOBAL_50_250_DOCS_API_KEY}`;
+    try {
+      const response = await fetch(url);
+      const json = await response.json();
+      res.send(json);
+    } catch (error) {
+      res.status(500).send(error);
+    }
+  }));
+};

--- a/sites/profoodworld.com/server/routes/index.js
+++ b/sites/profoodworld.com/server/routes/index.js
@@ -2,10 +2,14 @@ const content = require('@pmmi-media-group/package-shared/routes/content');
 const home = require('./home');
 const publishedContent = require('./published-content');
 const websiteSection = require('./website-section');
+const sheets = require('./global-50-250-sheets');
 
 module.exports = (app) => {
   // Homepage
   home(app);
+
+  // Handle Global 50 & 250 google sheets request on /__global-50-250-sheets?src=${sheetSrc}
+  sheets(app);
 
   // Content
   content(app);


### PR DESCRIPTION
add route to handle googel sheets api  request for global 250 & global 50 sheet ajax calls

Example request
http://localhost:9713/__global-50-250-sheets?src=https://content-sheets.googleapis.com/v4/spreadsheets/1rj6xZKDJQcyCVIoDBIhH4hGW31BrIcqBAa_Uq5AyZyI/values/2019Global250

This part needs to be update before update the tag updates can happen in gtm for these datatable renders.  

https://trello.com/c/MqU7ylzE/125-global-250-food-beverage-and-global-50-alcohol-tables-are-not-pulling-data-through 