### PR TITLE
Change name of navigation item

### DIFF
--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -41,7 +41,7 @@ module.exports = {
         { href: '/downloads', label: 'Downloads' },
         { href: '/page/oem-newsletter', label: 'Newsletters', target: '_blank' },
         { href: '/page/magazine', label: 'Magazine' },
-        { href: '/leaders', label: 'Tech Trendsetters' },
+        { href: '/leaders', label: 'OEM Partner Leaders' },
         { href: '/videos', label: 'Videos' },
         { href: '/podcasts', label: 'Podcasts' },
         // { href: '/page/digital-editions', label: 'Digital Editions' },


### PR DESCRIPTION
'Tech Trendsetters' changed to 'OEM Partner Leaders'
<img width="374" alt="Screen Shot 2021-10-05 at 7 10 53 AM" src="https://user-images.githubusercontent.com/64623209/136020077-e2d3c3d5-1e9a-41bb-82a8-970bfe84935f.png">
