### PR TITLE
Add social sharing to the top of the content pages

### DIFF
--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -61,6 +61,14 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                   <marko-web-content-published block-name=blockName obj=content />
                 </if>
               </default-theme-page-dates>
+              <marko-web-social-sharing
+                path=content.siteContext.path
+                providers=["print", "facebook", "linkedin", "twitter", "pinterest"]
+                print-path=`/print/content/${content.id}`
+                title=content.name
+                description=content.teaser
+                media=get(content, "primaryImage.src")
+              />
             </div>
           </div>
         </@section>


### PR DESCRIPTION
<img width="1213" alt="Screen Shot 2021-10-26 at 3 04 15 PM" src="https://user-images.githubusercontent.com/2855198/138954092-0604a924-52b8-4021-831a-55c973b46211.png">
