### PR TITLE
Remove sortField when searchQuery is not present.

### DIFF
--- a/packages/shared/routes/search.js
+++ b/packages/shared/routes/search.js
@@ -1,3 +1,4 @@
+const { get } = require('@parameter1/base-cms-object-path');
 const MarkoWebSearchConfig = require('@parameter1/base-cms-marko-web-search/config');
 const middleware = require('@parameter1/base-cms-marko-web-search/middleware');
 const template = require('../templates/search');
@@ -10,5 +11,14 @@ module.exports = (app) => {
     contentTypes,
     assignedToWebsiteSectionIds,
   });
-  app.get('/search', middleware({ config, template }));
+  app.get('/search', (req, res, next) => {
+    if (!get(req, 'query.searchQuery') && get(req, 'query.sortField')) {
+      const params = new URLSearchParams(get(req, 'query'));
+      params.delete('sortField');
+      params.delete('searchQuery');
+      if (`${params}`) res.redirect(301, `${get(req, 'route.path')}?${params}`);
+      else res.redirect(301, '/search');
+    }
+    next();
+  }, middleware({ config, template }));
 };


### PR DESCRIPTION
Currently on production the following happens if you remove the searchQuery with a sortField applied:
<img width="1920" alt="Screen Shot 2022-01-31 at 3 21 06 PM" src="https://user-images.githubusercontent.com/46794001/151875958-38a40ad5-b117-499b-a0a6-91971f325045.png">

This PR corrects it to properly remove like so:

With searchQuery and sortField applied:
<img width="1920" alt="Screen Shot 2022-01-31 at 3 24 57 PM" src="https://user-images.githubusercontent.com/46794001/151876033-4b8e2146-0695-4d0f-8e82-ae09ecbab284.png">


Following removal of searchQuery:
<img width="1920" alt="Screen Shot 2022-01-31 at 3 26 11 PM" src="https://user-images.githubusercontent.com/46794001/151875997-2952e2ef-6b8f-4158-ad7a-653928e02072.png">
 