### PR TITLE
Add contextual leaders block to content layout

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -156,6 +156,10 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     </div>
   </@section>
 
+  <@section>
+    <global-leaders-contextual content-id=id />
+  </@section>
+
   <@section|{ content }|>
     <theme-related-stories-block
       content-id=content.id

--- a/packages/global/components/leaders/contextual.marko
+++ b/packages/global/components/leaders/contextual.marko
@@ -4,15 +4,18 @@ $ const { contentId } = input;
 <if(contentId && site.get("leaders.enabled"))>
   <marko-web-leaders props={
     contentId,
+    open: "auto",
+    iconSet: "chevron",
+    expanded: false,
     sectionAlias: site.get("leaders.alias"),
     headerImgSrc: site.get("leaders.header.imgSrc"),
     headerImgAlt: site.get("leaders.title"),
     displayCallout: false,
     offsetTop: 50,
     viewAllHref: '/leaders',
+    columns: 1,
     mediaQueries: [
       { prop: "columns", value: 2, query: "(min-width: 700px)" },
-      { prop: "columns", value: 1, query: "(max-width: 699px)" },
     ],
     calloutPrefix: site.get("leaders.calloutPrefix") || "Browse these",
     calloutValue: site.get("leaders.calloutValue") || "leading suppliers",

--- a/packages/theme-monorail-leaders/browser/containers/columns.vue
+++ b/packages/theme-monorail-leaders/browser/containers/columns.vue
@@ -28,7 +28,7 @@ export default {
     classes() {
       const col = 'leaders-col';
       const classes = [col];
-      if (this.number > 1) classes.push(`${col}--${this.number}`);
+      if (this.number > 1 && this.sections.length > 1) classes.push(`${col}--${this.number}`);
       return classes;
     },
     columns() {


### PR DESCRIPTION
<img width="629" alt="Screen Shot 2022-02-26 at 5 08 47 PM" src="https://user-images.githubusercontent.com/3845869/155861903-cfa4f84e-3299-4fd9-834f-4f27096c1d85.png">
<img width="557" alt="Screen Shot 2022-02-26 at 5 09 04 PM" src="https://user-images.githubusercontent.com/3845869/155861904-ed2adf05-a0d0-4896-9313-8e196f4f1a6e.png">
<img width="572" alt="Screen Shot 2022-02-26 at 5 09 25 PM" src="https://user-images.githubusercontent.com/3845869/155861906-cf544e9b-47c9-43f8-ad38-d2d7db931484.png">
