### PR TITLE
Sort company contacts based on published date.

### DIFF
--- a/packages/common/graphql/fragment-factories/content-company.js
+++ b/packages/common/graphql/fragment-factories/content-company.js
@@ -56,7 +56,7 @@ fragment WebsiteContentCompanyFragment on Content {
 
     isLeader: hasWebsiteSchedule(input: { sectionAlias: "${leadersAlias}" })
 
-    contacts: publicContacts {
+    contacts: publicContacts(input: { sort: { field: published, order: asc }}) {
       edges {
         node {
           id

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -55,7 +55,6 @@ module.exports = (options = {}) => {
       omedaIdentityX(app, {
         clientKey: omedaConfig.clientKey,
         brandKey: omedaConfig.brandKey,
-        clientKey: omedaConfig.clientKey,
         appId: omedaConfig.appId,
         inputId: omedaConfig.inputId,
         rapidIdentProductId: get(omedaConfig, 'rapidIdentification.productId'),


### PR DESCRIPTION
By default this sorts by ID descending (Highest ID # to lowest) which outside of recreating contacts to alter the order there isn’t any other means to change the order, rather than force recreation etc. of existing contacts, sorting on published date gives some sort of control point. (And effectively works as a drop in replacement, as presumably any higher ID numbers have a more recent publish date thus putting it at the top anyways)

<img width="1792" alt="Screen Shot 2022-04-11 at 8 26 15 AM" src="https://user-images.githubusercontent.com/46794001/162750528-97ede540-b2e2-4eb1-b02b-da82b1c90464.png">

