### PR TITLE
Add translation support in Monorail Vue components.

### DIFF
--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -8,7 +8,7 @@ import imageHeight from "@parameter1/base-cms-marko-web/components/node/utils/im
 $ const { id, type, pageNode, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 $ const { site, i18n } = out.global;
-$ const lang = site.config.lang || 'en';
+$ const lang = site.config.lang || "en";
 
 <global-content-wrapper-layout
   id=id

--- a/packages/theme-monorail/browser/comment-toggle-button.vue
+++ b/packages/theme-monorail/browser/comment-toggle-button.vue
@@ -35,6 +35,10 @@ export default {
       type: String,
       required: true,
     },
+    lang: {
+      type: String,
+      default: 'en',
+    },
   },
 
   data: () => ({

--- a/packages/theme-monorail/browser/comment-toggle-button.vue
+++ b/packages/theme-monorail/browser/comment-toggle-button.vue
@@ -4,13 +4,14 @@
     type="button"
     @click="toggle"
   >
-    <span>View All Comments</span>
+    <span>{{ translate("viewAllComments") }}</span>
   </button>
 </template>
 
 <script>
 import EventBus from '@parameter1/base-cms-marko-web/browser/event-bus';
 import get from '@parameter1/base-cms-marko-web-identity-x/browser/utils/get';
+import i18n from './i18n-vue';
 
 export default {
 
@@ -77,6 +78,9 @@ export default {
       EventBus.$emit('comments-expanded', this.expanded);
       const elements = document.querySelectorAll(this.targets.join(','));
       Array.prototype.forEach.call(elements, el => el.classList.toggle(this.toggleClass));
+    },
+    translate(key) {
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/theme-monorail/browser/inline-newsletter-form.vue
+++ b/packages/theme-monorail/browser/inline-newsletter-form.vue
@@ -11,6 +11,7 @@
       :image-srcset="imageSrcset"
       :recaptcha-site-key="recaptchaSiteKey"
       :privacy-policy-link="privacyPolicyLink"
+      :lang="lang"
       @submit="stepOneSubmit"
       @subscribe="$emit('subscribe', $event)"
       @focus="$emit('focus', { step: 1 })"
@@ -24,6 +25,7 @@
       :newsletters="newsletters"
       :demographic="demographic"
       :recaptcha-site-key="recaptchaSiteKey"
+      :lang="lang"
       as-card
       @submit="$emit('submit', { step: 2 })"
       @subscribe="$emit('subscribe', $event)"
@@ -89,6 +91,10 @@ export default {
     privacyPolicyLink: {
       type: Object,
       required: true,
+    },
+    lang: {
+      type: String,
+      default: 'en',
     },
   },
 

--- a/packages/theme-monorail/browser/newsletter-signup-form/privacy-policy.vue
+++ b/packages/theme-monorail/browser/newsletter-signup-form/privacy-policy.vue
@@ -1,15 +1,19 @@
 <template>
   <div :class="`${blockName}__privacy-policy`">
-    By providing your email, you agree to our
+    {{ translate("emailProviding") }}
     <a :href="privacyPolicyLink.href" :target="privacyPolicyLink.target" rel="noopener">
       {{ privacyPolicyLink.label }}</a>.
-    This site is protected by reCAPTCHA and the Google
-    <a href="https://policies.google.com/privacy">Privacy Policy</a> and
-    <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+    {{ translate("protectedBy") }}
+    <a href="https://policies.google.com/privacy">{{ translate("privacyPolicy") }}</a>
+    {{ translate("and") }}
+    <a href="https://policies.google.com/terms">{{ translate("termsOfService") }}</a>
+    {{ translate("apply") }}
   </div>
 </template>
 
 <script>
+import i18n from '../i18n-vue';
+
 export default {
   props: {
     blockName: {
@@ -19,6 +23,15 @@ export default {
     privacyPolicyLink: {
       type: Object,
       required: true,
+    },
+    lang: {
+      type: String,
+      default: 'en',
+    },
+  },
+  methods: {
+    translate(key) {
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/theme-monorail/browser/newsletter-signup-form/sign-up-button.vue
+++ b/packages/theme-monorail/browser/newsletter-signup-form/sign-up-button.vue
@@ -12,13 +12,16 @@
       >
         <span class="sr-only">Loading...</span>
       </div>
-      <span>{{ label }}</span>
+      <span v-if="label">{{ label }}</span>
+      <span v-else>{{ translate("signUp") }}</span>
     </div>
   </button>
 </template>
 
 
 <script>
+import i18n from '../i18n-vue';
+
 export default {
   props: {
     isLoading: {
@@ -27,11 +30,20 @@ export default {
     },
     label: {
       type: String,
-      default: 'Sign Up',
+      default: '',
     },
     disabled: {
       type: Boolean,
       default: false,
+    },
+    lang: {
+      type: String,
+      default: 'en',
+    },
+  },
+  methods: {
+    translate(key) {
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/theme-monorail/browser/newsletter-signup-form/step2.vue
+++ b/packages/theme-monorail/browser/newsletter-signup-form/step2.vue
@@ -175,6 +175,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    lang: {
+      type: String,
+      default: 'en',
+    },
   },
 
   data: () => ({

--- a/packages/theme-monorail/browser/newsletter-signup-form/step2.vue
+++ b/packages/theme-monorail/browser/newsletter-signup-form/step2.vue
@@ -2,7 +2,7 @@
   <div :class="classNames">
     <div :class="`${blockName}__card-header`">
       <check-icon :class="`${blockName}__check-icon`" />
-      Signed up for the {{ defaultNewsletter.name }}
+      {{ translate("signedUpFor") }} {{ defaultNewsletter.name }}
     </div>
     <form
       :class="`${blockName}__card-body`"
@@ -14,10 +14,10 @@
       >
         <div v-show="!isComplete">
           <div :class="`${blockName}__header`">
-            Complete your sign-up
+            {{ translate("completeSignUp") }}
           </div>
           <div :class="`${blockName}__about-you`">
-            About you
+            {{ translate("aboutYou") }}
           </div>
           <div :class="`${blockName}__form`">
             <input-form-group
@@ -25,7 +25,7 @@
               :block-name="blockName"
               :disabled="isLoading"
               field="company-name"
-              label="Company Name"
+              :label="companyName"
               required
               @focus="didFocus = true"
             />
@@ -40,7 +40,7 @@
               @focus="didFocus = true"
             >
               <option value="">
-                Select
+                {{ translate("select") }}
               </option>
               <option
                 v-for="value in demographic.values"
@@ -64,7 +64,7 @@
 
           <div v-if="newsletters.length">
             <div :class="`${blockName}__subscriptions-header`">
-              Choose your subscriptions
+              {{ translate("chooseSubscriptions") }}
             </div>
 
             <div :class="`${blockName}__subscriptions row`">
@@ -90,9 +90,10 @@
                 :class="`${blockName}__form-button`"
                 :is-loading="isLoading"
                 :disabled="isComplete"
+                :lang="lang"
               />
             </div>
-            <privacy-policy :block-name="blockName" />
+            <privacy-policy :block-name="blockName" :lang="lang" />
           </div>
         </div>
       </transition>
@@ -102,11 +103,10 @@
       >
         <div v-show="formHidden">
           <div :class="`${blockName}__thank-you-header`">
-            Thank you for subscribing!
+            {{ translate("thankYou") }}
           </div>
           <p class="mb-0">
-            You should start receiving your subscription in the next 24 hours
-            along with a special welcome from the experts at <em>{{ siteName }}</em>.
+            {{ translate("startReceiving") }} <em>{{ siteName }}</em>.
           </p>
         </div>
       </transition>
@@ -129,6 +129,7 @@ import SelectFormGroup from './select-form-group.vue';
 import SignUpButton from './sign-up-button.vue';
 
 import getRecaptchaToken from './get-recaptcha-token';
+import i18n from '../i18n-vue';
 
 export default {
   components: {
@@ -203,6 +204,9 @@ export default {
       if (this.inPushdown) classNames.push(`${blockName}--in-pushdown`);
       return classNames;
     },
+    companyName() {
+      return i18n(this.lang, 'companyName');
+    },
   },
 
   watch: {
@@ -260,6 +264,10 @@ export default {
       } finally {
         this.isLoading = false;
       }
+    },
+
+    translate(key) {
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/theme-monorail/browser/site-newsletter-menu.vue
+++ b/packages/theme-monorail/browser/site-newsletter-menu.vue
@@ -12,6 +12,7 @@
         :image-srcset="imageSrcset"
         :recaptcha-site-key="recaptchaSiteKey"
         :privacy-policy-link="privacyPolicyLink"
+        :lang="lang"
         @submit="stepOneSubmit"
         @subscribe="$emit('subscribe', $event)"
         @focus="$emit('focus', { step: 1 })"
@@ -25,6 +26,7 @@
         :newsletters="newsletters"
         :demographic="demographic"
         :recaptcha-site-key="recaptchaSiteKey"
+        :lang="lang"
         in-pushdown
         @submit="$emit('submit', { step: 2 })"
         @subscribe="$emit('subscribe', $event)"
@@ -96,6 +98,10 @@ export default {
     initiallyExpanded: {
       type: Boolean,
       default: false,
+    },
+    lang: {
+      type: String,
+      default: 'en',
     },
   },
 

--- a/packages/theme-monorail/browser/site-newsletter-menu/step1.vue
+++ b/packages/theme-monorail/browser/site-newsletter-menu/step1.vue
@@ -103,6 +103,10 @@ export default {
       type: Object,
       required: true,
     },
+    lang: {
+      type: String,
+      default: 'en',
+    },
   },
 
   data: () => ({

--- a/packages/theme-monorail/browser/site-newsletter-menu/step1.vue
+++ b/packages/theme-monorail/browser/site-newsletter-menu/step1.vue
@@ -29,11 +29,16 @@
           required
           @focus="didFocus = true"
         >
-        <privacy-policy :block-name="blockName" :privacy-policy-link="privacyPolicyLink" />
+        <privacy-policy
+          :block-name="blockName"
+          :privacy-policy-link="privacyPolicyLink"
+          :lang="lang"
+        />
         <sign-up-button
           :class="element('form-button')"
           :is-loading="isLoading"
           :disabled="disabled"
+          :lang="lang"
         />
       </form>
 

--- a/packages/theme-monorail/browser/translations-vue.js
+++ b/packages/theme-monorail/browser/translations-vue.js
@@ -9,6 +9,17 @@ export default {
     termsOfService: 'Terms of Service',
     apply: 'apply.',
     signUp: 'Sign Up',
+    // Email Signup step 2:
+    signedUpFor: 'Signed up for the',
+    completeSignUp: 'Complete your sign-up',
+    aboutYou: 'About you',
+    companyName: 'Company Name',
+    select: 'Select',
+    chooseSubscriptions: 'Choose your subscriptions',
+    thankYou: 'Thank you for subscribing!',
+    startReceiving: 'You should start receiving your subscription in the next 24 hours along with a special welcome from the experts at',
+    // Comments
+    viewAllComments: 'View All Comments',
   },
   es: {
     visitSiteLabel: 'Visite el sitio',
@@ -20,5 +31,16 @@ export default {
     termsOfService: 'Terms of Service',
     apply: 'apply.',
     signUp: '¡Sign Up!',
+    // Email Signup step 2:
+    signedUpFor: 'Signed up for the',
+    completeSignUp: 'Complete your sign-up',
+    aboutYou: 'About you',
+    companyName: 'Company Name',
+    select: 'Select',
+    chooseSubscriptions: 'Choose your subscriptions',
+    thankYou: 'Thank you for subscribing!',
+    startReceiving: 'You should start receiving your subscription in the next 24 hours along with a special welcome from the experts at',
+    // Comments
+    viewAllComments: 'View All Comments',
   },
 };

--- a/packages/theme-monorail/browser/translations-vue.js
+++ b/packages/theme-monorail/browser/translations-vue.js
@@ -1,8 +1,24 @@
 export default {
   en: {
     visitSiteLabel: 'Visit Site',
+    // Email Signup Privacy Policy
+    emailProviding: 'By providing your email, you agree to our',
+    protectedBy: 'This site is protected by reCAPTCHA and the Google',
+    privacyPolicy: 'Privacy Policy',
+    and: 'and',
+    termsOfService: 'Terms of Service',
+    apply: 'apply.',
+    signUp: 'Sign Up',
   },
   es: {
     visitSiteLabel: 'Visite el sitio',
+    // Email Signup Privacy Policy
+    emailProviding: 'By providing your email, you agree to our',
+    protectedBy: 'This site is protected by reCAPTCHA y the Google',
+    privacyPolicy: 'Privacy Policy',
+    and: 'y',
+    termsOfService: 'Terms of Service',
+    apply: 'apply.',
+    signUp: '¡Sign Up!',
   },
 };

--- a/packages/theme-monorail/components/blocks/newsletter-signup-banner.marko
+++ b/packages/theme-monorail/components/blocks/newsletter-signup-banner.marko
@@ -14,7 +14,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.signupBanner");
 
-$ const lang = site.config.lang || 'en';
+$ const lang = site.config.lang || "en";
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 120, auto: "format,compress" }) : null;
 $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
 

--- a/packages/theme-monorail/components/blocks/newsletter-signup-banner.marko
+++ b/packages/theme-monorail/components/blocks/newsletter-signup-banner.marko
@@ -14,6 +14,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.signupBanner");
 
+$ const lang = site.config.lang || 'en';
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 120, auto: "format,compress" }) : null;
 $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
 
@@ -32,6 +33,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
       imageSrcset,
       recaptchaSiteKey: recaptcha.siteKey,
       privacyPolicyLink: privacyPolicy,
+      lang
     }
   />
 </if>

--- a/packages/theme-monorail/components/identity-x/comment-stream.marko
+++ b/packages/theme-monorail/components/identity-x/comment-stream.marko
@@ -1,7 +1,9 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
+$ const { site } = out.global;
 $ const content = getAsObject(input, "content");
+$ const lang = site.config.lang || 'en';
 
 <div class="comment-stream">
   <div class="idx-comment-stream-wrapper">
@@ -20,7 +22,8 @@ $ const content = getAsObject(input, "content");
         isExpanded: false,
         classes: "btn btn-secondary comment-stream__toggle-btn",
         targets: [".idx-comment-stream-wrapper"],
-        toggleClass: "idx-comment-stream-wrapper--open"
+        toggleClass: "idx-comment-stream-wrapper--open",
+        lang
       }
     />
   </div>

--- a/packages/theme-monorail/components/identity-x/comment-stream.marko
+++ b/packages/theme-monorail/components/identity-x/comment-stream.marko
@@ -3,7 +3,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { site } = out.global;
 $ const content = getAsObject(input, "content");
-$ const lang = site.config.lang || 'en';
+$ const lang = site.config.lang || "en";
 
 <div class="comment-stream">
   <div class="idx-comment-stream-wrapper">

--- a/packages/theme-monorail/components/site-newsletter-menu.marko
+++ b/packages/theme-monorail/components/site-newsletter-menu.marko
@@ -13,7 +13,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.pushdown");
 
-$ const lang = site.config.lang || 'en';
+$ const lang = site.config.lang || "en";
 $ const { hasCookie, fromEmail } = getAsObject(out.global, "newsletterState");
 $ const initiallyExpanded = (!hasCookie && !fromEmail) ? true : false;
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;

--- a/packages/theme-monorail/components/site-newsletter-menu.marko
+++ b/packages/theme-monorail/components/site-newsletter-menu.marko
@@ -13,6 +13,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.pushdown");
 
+$ const lang = site.config.lang || 'en';
 $ const { hasCookie, fromEmail } = getAsObject(out.global, "newsletterState");
 $ const initiallyExpanded = (!hasCookie && !fromEmail) ? true : false;
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
@@ -35,6 +36,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
       initiallyExpanded,
       recaptchaSiteKey: recaptcha.siteKey,
       privacyPolicyLink: privacyPolicy,
+      lang
     }
   />
 </if>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-04-20 at 2 50 49 PM" src="https://user-images.githubusercontent.com/46794001/164312349-8e810eb9-2e5e-45e2-a41f-6cb36fa231e5.png">


With the exception of the top stories block in the menu (which seems to load an HTML "blob" off a request including the heading "Top Stories" this should cover all the Vue components in the Monorail theme for translation support.

There will need to be some site CSS additions for things like Image Captions and the little "Advertisement" that goes above ads but that will be covered in a separate PR.