### PR TITLE
Remove duplicate IDENTITYX_API_TOKEN declaration from docker-compose env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ x-node-defaults: &node
 
 x-env-defaults: &env
   GTM_CONTAINER_ID: ${GTM_CONTAINER_ID}
-  IDENTITYX_API_TOKEN: ${IDENTITYX_API_TOKEN-(unset)}
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
   NODE_ENV: development


### PR DESCRIPTION
Ref: https://github.com/parameter1/pmmi-media-group-websites/commit/5f5ef72af89b8e76dd9be2ae237375650f8ed33f
https://github.com/parameter1/pmmi-media-group-websites/blob/5f5ef72af89b8e76dd9be2ae237375650f8ed33f/docker-compose.yml#L17