### PR TITLE
Add contentGatingHandler() support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-env-defaults: &env
   ENABLE_IDENTITY_X: ${ENABLE_IDENTITY_X-1}
   RECAPTCHA_V3_SITE_KEY: ${RECAPTCHA_V3_SITE_KEY-(unset)}
   RECAPTCHA_V3_SECRET_KEY: ${RECAPTCHA_V3_SECRET_KEY-(unset)}
+  CONTENT_GATING_HANDLER_ENABLED: ${CONTENT_GATING_HANDLER_ENABLED-false}
 
 x-env-tauron: &env-tauron
   GRAPHQL_URI: ${GRAPHQL_URI-https://tauron.graphql.base.parameter1.com}

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -2,7 +2,7 @@ import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import contentIframe from "@pmmi-media-group/package-global/utils/content-iframe";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
-$ const { site, contentGatingHandler, olyEncId } = out.global;
+$ const { site, contentGatingHandler, req } = out.global;
 $ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 
@@ -75,7 +75,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
               />
             </else-if>
 
-            $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, olyEncId }));
+            $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, req }));
             $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
             <marko-web-identity-x-access|context|
               enabled=requiresRegistration

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -2,7 +2,7 @@ import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import contentIframe from "@pmmi-media-group/package-global/utils/content-iframe";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
-$ const { site } = out.global;
+$ const { site, contentGatingHandler, olyEncId } = out.global;
 $ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 
@@ -75,7 +75,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
               />
             </else-if>
 
-            $ const requiresRegistration = get(content, "userRegistration.isCurrentlyRequired");
+            $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, olyEncId }));
             $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
             <marko-web-identity-x-access|context|
               enabled=requiresRegistration

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -16,7 +16,7 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const recaptcha = require('./config/recaptcha');
 
-const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
+const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED;
 const defaultContentGatingHandler = require('./utils/content-gating-handler');
 
 const routes = (siteRoutes, siteConfig) => (app) => {

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -17,25 +17,7 @@ const idxRouteTemplates = require('./templates/user');
 const recaptcha = require('./config/recaptcha');
 
 const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
-const defaultContentGatingHandler = ({ content, olyEncId }) => {
-  // If there is an associated olyEncId skip as they are considered identitfied.
-  if (olyEncId) return false;
-
-  // Gate the following content types only.
-  const typesToGate = [
-    'article',
-    'blog',
-    'news',
-  ];
-  if (typesToGate.includes(content.type)) return true;
-
-  return false;
-};
-const getId = (value) => {
-  if (!value) return null;
-  const trimmed = `${value}`.trim();
-  return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
-};
+const defaultContentGatingHandler = require('./utils/content-gating-handler');
 
 const routes = (siteRoutes, siteConfig) => (app) => {
   // Handle submissions on /__inquiry
@@ -71,20 +53,6 @@ module.exports = (options = {}) => {
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
 
       set(app.locals, 'contentGatingHandler', contentGatingHandler);
-
-      // Look for and set global for olyEncId off query params or by cookie
-      app.use((req, res, next) => {
-        const {
-          query,
-          cookies,
-        } = req;
-
-        const idFromQuery = getId(query.oly_enc_id);
-        const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
-        const olyEncId = idFromQuery || idFromCookie;
-        set(app.locals, 'olyEncId', olyEncId);
-        next();
-      });
 
       // Use paginated middleware
       app.use(paginated());

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -16,8 +16,8 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const recaptcha = require('./config/recaptcha');
 
+const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
 const defaultContentGatingHandler = ({ content, olyEncId }) => {
-  console.log(olyEncId);
   // If there is an associated olyEncId skip as they are considered identitfied.
   if (olyEncId) return false;
 
@@ -53,7 +53,10 @@ module.exports = (options = {}) => {
     includeContentTypes: ['Article'],
     excludeLabels: ['Sponsored'],
   };
-  const contentGatingHandler = options.contentGatingHandler || defaultContentGatingHandler;
+  // Allow for env enable/disable of contentGatingHandler
+  const contentGatingHandler = (contentGatingHandlerEnabled)
+    ? options.contentGatingHandler || defaultContentGatingHandler
+    : () => false;
   return startServer({
     ...options,
     routes: routes(options.routes, options.siteConfig),

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -16,6 +16,27 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const recaptcha = require('./config/recaptcha');
 
+const defaultContentGatingHandler = ({ content, olyEncId }) => {
+  console.log(olyEncId);
+  // If there is an associated olyEncId skip as they are considered identitfied.
+  if (olyEncId) return false;
+
+  // Gate the following content types only.
+  const typesToGate = [
+    'article',
+    'blog',
+    'news',
+  ];
+  if (typesToGate.includes(content.type)) return true;
+
+  return false;
+};
+const getId = (value) => {
+  if (!value) return null;
+  const trimmed = `${value}`.trim();
+  return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
+};
+
 const routes = (siteRoutes, siteConfig) => (app) => {
   // Handle submissions on /__inquiry
   loadInquiry(app);
@@ -32,6 +53,7 @@ module.exports = (options = {}) => {
     includeContentTypes: ['Article'],
     excludeLabels: ['Sponsored'],
   };
+  const contentGatingHandler = options.contentGatingHandler || defaultContentGatingHandler;
   return startServer({
     ...options,
     routes: routes(options.routes, options.siteConfig),
@@ -44,6 +66,22 @@ module.exports = (options = {}) => {
     onStart: async (app) => {
       if (typeof onStart === 'function') await onStart(app);
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+
+      set(app.locals, 'contentGatingHandler', contentGatingHandler);
+
+      // Look for and set global for olyEncId off query params or by cookie
+      app.use((req, res, next) => {
+        const {
+          query,
+          cookies,
+        } = req;
+
+        const idFromQuery = getId(query.oly_enc_id);
+        const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
+        const olyEncId = idFromQuery || idFromCookie;
+        set(app.locals, 'olyEncId', olyEncId);
+        next();
+      });
 
       // Use paginated middleware
       app.use(paginated());

--- a/packages/global/utils/content-gating-handler.js
+++ b/packages/global/utils/content-gating-handler.js
@@ -1,7 +1,6 @@
 const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
 
 module.exports = ({ content, req }) => {
-  // const currentEncId = olyticsCookie.parseFrom(req);
   const incomingEncId = olyticsCookie.clean(req.query.oly_enc_id);
 
   if (incomingEncId) return false;

--- a/packages/global/utils/content-gating-handler.js
+++ b/packages/global/utils/content-gating-handler.js
@@ -1,0 +1,18 @@
+const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
+
+module.exports = ({ content, req }) => {
+  // const currentEncId = olyticsCookie.parseFrom(req);
+  const incomingEncId = olyticsCookie.clean(req.query.oly_enc_id);
+
+  if (incomingEncId) return false;
+
+  // Gate the following content types only.
+  const typesToGate = [
+    'article',
+    'blog',
+    'news',
+  ];
+  if (typesToGate.includes(content.type)) return true;
+
+  return false;
+};

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -14,8 +14,9 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const idxNavItems = require('./config/identity-x-nav');
 
+const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
+
 const defaultContentGatingHandler = ({ content, olyEncId }) => {
-  console.log(olyEncId);
   // If there is an associated olyEncId skip as they are considered identitfied.
   if (olyEncId) return false;
 
@@ -48,7 +49,10 @@ const routes = siteRoutes => (app) => {
 
 module.exports = (options = {}) => {
   const { onStart } = options;
-  const contentGatingHandler = options.contentGatingHandler || defaultContentGatingHandler;
+  // Allow for env enable/disable of contentGatingHandler
+  const contentGatingHandler = (contentGatingHandlerEnabled)
+    ? options.contentGatingHandler || defaultContentGatingHandler
+    : () => false;
   return startServer({
     ...options,
     routes: routes(options.routes),

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -14,7 +14,7 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const idxNavItems = require('./config/identity-x-nav');
 
-const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
+const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED;
 
 const defaultContentGatingHandler = require('./utils/content-gating-handler');
 

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -16,25 +16,7 @@ const idxNavItems = require('./config/identity-x-nav');
 
 const contentGatingHandlerEnabled = process.env.CONTENT_GATING_HANDLER_ENABLED
 
-const defaultContentGatingHandler = ({ content, olyEncId }) => {
-  // If there is an associated olyEncId skip as they are considered identitfied.
-  if (olyEncId) return false;
-
-  // Gate the following content types only.
-  const typesToGate = [
-    'article',
-    'blog',
-    'news',
-  ];
-  if (typesToGate.includes(content.type)) return true;
-
-  return false;
-};
-const getId = (value) => {
-  if (!value) return null;
-  const trimmed = `${value}`.trim();
-  return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
-};
+const defaultContentGatingHandler = require('./utils/content-gating-handler');
 
 const routes = siteRoutes => (app) => {
   // Shared/global routes (all sites)
@@ -64,20 +46,6 @@ module.exports = (options = {}) => {
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
 
       set(app.locals, 'contentGatingHandler', contentGatingHandler);
-
-      // Look for and set global for olyEncId off query params or by cookie
-      app.use((req, res, next) => {
-        const {
-          query,
-          cookies,
-        } = req;
-
-        const idFromQuery = getId(query.oly_enc_id);
-        const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
-        const olyEncId = idFromQuery || idFromCookie;
-        set(app.locals, 'olyEncId', olyEncId);
-        next();
-      });
 
       // i18n
       const i18n = v => v;

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -14,6 +14,27 @@ const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
 const idxNavItems = require('./config/identity-x-nav');
 
+const defaultContentGatingHandler = ({ content, olyEncId }) => {
+  console.log(olyEncId);
+  // If there is an associated olyEncId skip as they are considered identitfied.
+  if (olyEncId) return false;
+
+  // Gate the following content types only.
+  const typesToGate = [
+    'article',
+    'blog',
+    'news',
+  ];
+  if (typesToGate.includes(content.type)) return true;
+
+  return false;
+};
+const getId = (value) => {
+  if (!value) return null;
+  const trimmed = `${value}`.trim();
+  return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
+};
+
 const routes = siteRoutes => (app) => {
   // Shared/global routes (all sites)
   sharedRoutes(app);
@@ -27,6 +48,7 @@ const routes = siteRoutes => (app) => {
 
 module.exports = (options = {}) => {
   const { onStart } = options;
+  const contentGatingHandler = options.contentGatingHandler || defaultContentGatingHandler;
   return startServer({
     ...options,
     routes: routes(options.routes),
@@ -36,6 +58,22 @@ module.exports = (options = {}) => {
     onStart: async (app) => {
       if (typeof onStart === 'function') await onStart(app);
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+
+      set(app.locals, 'contentGatingHandler', contentGatingHandler);
+
+      // Look for and set global for olyEncId off query params or by cookie
+      app.use((req, res, next) => {
+        const {
+          query,
+          cookies,
+        } = req;
+
+        const idFromQuery = getId(query.oly_enc_id);
+        const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
+        const olyEncId = idFromQuery || idFromCookie;
+        set(app.locals, 'olyEncId', olyEncId);
+        next();
+      });
 
       // i18n
       const i18n = v => v;

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -3,7 +3,12 @@ import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import getContentPreview from "../../utils/get-content-preview";
 
-$ const { site, GAM } = out.global;
+$ const {
+  site,
+  GAM,
+  contentGatingHandler,
+  olyEncId,
+} = out.global;
 $ const { id, type, pageNode } = data;
 $ const { lang = "en" } = getAsObject(site, "config");
 
@@ -78,7 +83,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <shared-content-media-block content=content blockName=blockName />
               <default-theme-content-contact-details obj=content />
 
-              $ const requiresRegistration = get(content, "userRegistration.isCurrentlyRequired");
+              $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, olyEncId }));
               $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
               <marko-web-identity-x-access|context|
                 enabled=requiresRegistration

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -7,7 +7,7 @@ $ const {
   site,
   GAM,
   contentGatingHandler,
-  olyEncId,
+  req,
 } = out.global;
 $ const { id, type, pageNode } = data;
 $ const { lang = "en" } = getAsObject(site, "config");
@@ -83,7 +83,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <shared-content-media-block content=content blockName=blockName />
               <default-theme-content-contact-details obj=content />
 
-              $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, olyEncId }));
+              $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, req }));
               $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
               <marko-web-identity-x-access|context|
                 enabled=requiresRegistration

--- a/packages/shared/utils/content-gating-handler.js
+++ b/packages/shared/utils/content-gating-handler.js
@@ -1,7 +1,6 @@
 const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
 
 module.exports = ({ content, req }) => {
-  // const currentEncId = olyticsCookie.parseFrom(req);
   const incomingEncId = olyticsCookie.clean(req.query.oly_enc_id);
 
   if (incomingEncId) return false;

--- a/packages/shared/utils/content-gating-handler.js
+++ b/packages/shared/utils/content-gating-handler.js
@@ -1,0 +1,18 @@
+const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
+
+module.exports = ({ content, req }) => {
+  // const currentEncId = olyticsCookie.parseFrom(req);
+  const incomingEncId = olyticsCookie.clean(req.query.oly_enc_id);
+
+  if (incomingEncId) return false;
+
+  // Gate the following content types only.
+  const typesToGate = [
+    'article',
+    'blog',
+    'news',
+  ];
+  if (typesToGate.includes(content.type)) return true;
+
+  return false;
+};

--- a/sites/global.mundopmmi.com/index.js
+++ b/sites/global.mundopmmi.com/index.js
@@ -12,6 +12,7 @@ module.exports = startServer({
   rootDir: __dirname,
   coreConfig,
   siteConfig,
+  contentGatingHandler: () => false,
   routes,
   redirectHandler,
   i18n: v => i18n[`${v}`.toLowerCase()] || v,

--- a/sites/mundopmmi.com/index.js
+++ b/sites/mundopmmi.com/index.js
@@ -12,6 +12,7 @@ module.exports = startServer({
   rootDir: __dirname,
   coreConfig,
   siteConfig,
+  contentGatingHandler: () => false,
   routes,
   redirectHandler,
   i18n: v => i18n[`${v}`.toLowerCase()] || v,


### PR DESCRIPTION
Add a defaultContentGatingHandler() for all site to use that will gate articles, blogs & news.  This is overwritten on Mundo. This means no additional gating applies in Mundo's case.  Also added support that requires the CONTENT_GATING_HANDLER_ENABLED env variable to be set for the new contentGatingHandler to work.