### PR TITLE
Change cheerio target selector to show first 2 p tags

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -82,7 +82,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
               required-access-level-ids=accessLevels
             >
               <if(!context.canAccess || context.requiresUserInput)>
-                $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(2)" });
+                $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });
                 <marko-web-content-body block-name=blockName obj={ body } />
 
                 <div class="content-page-preview-overlay" />

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -90,7 +90,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 required-access-level-ids=accessLevels
               >
                 <if(!context.canAccess || context.requiresUserInput)>
-                  $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(2)" });
+                  $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });
                   <marko-web-content-body block-name=blockName obj={ body } />
 
                   <div class="content-page-preview-overlay" />


### PR DESCRIPTION
Adjust the cheerio selector to show the first two p tags.  The old one way was only selecting the second p tag and showing it not the first two
<img width="1187" alt="Screen Shot 2022-06-06 at 8 12 11 AM" src="https://user-images.githubusercontent.com/3845869/172167448-916cef07-d823-4dc7-9206-cb741f72f3df.png">
.