### PR TITLE
Update homepage layout (section-list block & leaders block)

### DIFF
--- a/sites/global.mundopmmi.com/server/templates/index.marko
+++ b/sites/global.mundopmmi.com/server/templates/index.marko
@@ -24,7 +24,12 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <global-leaders-home-page />
+    <div class="row">
+      <div class="col-lg-8">
+        <global-leaders-home-page />
+      </div>
+      <div class="col-lg-4">PROMO CARDS</div>
+    </div>
   </@section>
 
   <@section>

--- a/sites/global.mundopmmi.com/server/templates/index.marko
+++ b/sites/global.mundopmmi.com/server/templates/index.marko
@@ -24,11 +24,11 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <theme-section-list-deck-block aliases=["automatizacion", "empaque", "procesamiento"] />
+    <global-leaders-home-page />
   </@section>
 
-<@section>
-    <global-leaders-home-page />
+  <@section>
+    <theme-section-list-deck-block aliases=["automatizacion", "empaque", "procesamiento"] />
   </@section>
 
   <@section>

--- a/sites/global.oemmagazine.org/server/templates/index.marko
+++ b/sites/global.oemmagazine.org/server/templates/index.marko
@@ -24,7 +24,12 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <global-leaders-home-page />
+    <div class="row">
+      <div class="col-lg-8">
+        <global-leaders-home-page />
+      </div>
+      <div class="col-lg-4">PROMO CARDS</div>
+    </div>
   </@section>
 
   <@section>

--- a/sites/global.oemmagazine.org/server/templates/index.marko
+++ b/sites/global.oemmagazine.org/server/templates/index.marko
@@ -24,11 +24,11 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <theme-section-list-deck-block aliases=["technology", "products", "business"] />
+    <global-leaders-home-page />
   </@section>
 
-<@section>
-    <global-leaders-home-page />
+  <@section>
+    <theme-section-list-deck-block aliases=["technology", "products", "business"] />
   </@section>
 
   <@section|{ aliases }|>

--- a/sites/global.packworld.com/server/templates/index.marko
+++ b/sites/global.packworld.com/server/templates/index.marko
@@ -24,7 +24,12 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <global-leaders-home-page />
+    <div class="row">
+      <div class="col-lg-8">
+        <global-leaders-home-page />
+      </div>
+      <div class="col-lg-4">PROMO CARDS</div>
+    </div>
   </@section>
 
   <@section>

--- a/sites/global.packworld.com/server/templates/index.marko
+++ b/sites/global.packworld.com/server/templates/index.marko
@@ -23,8 +23,12 @@ $ const { site } = out.global;
     />
   </@section>
 
-<@section>
+  <@section>
     <global-leaders-home-page />
+  </@section>
+
+  <@section>
+    <theme-section-list-deck-block aliases=["machinery", "design", "issues"] />
   </@section>
 
   <@section|{ aliases }|>

--- a/sites/global.profoodworld.com/server/templates/index.marko
+++ b/sites/global.profoodworld.com/server/templates/index.marko
@@ -24,7 +24,12 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <global-leaders-home-page />
+    <div class="row">
+      <div class="col-lg-8">
+        <global-leaders-home-page />
+      </div>
+      <div class="col-lg-4">PROMO CARDS</div>
+    </div>
   </@section>
 
   <@section>

--- a/sites/global.profoodworld.com/server/templates/index.marko
+++ b/sites/global.profoodworld.com/server/templates/index.marko
@@ -24,11 +24,11 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <theme-section-list-deck-block aliases=["processing-equipment", "automation", "food-safety"] />
+    <global-leaders-home-page />
   </@section>
 
-<@section>
-    <global-leaders-home-page />
+  <@section>
+    <theme-section-list-deck-block aliases=["processing-equipment", "automation", "food-safety"] />
   </@section>
 
   <@section|{ aliases }|>


### PR DESCRIPTION
UPDATED IMAGE LEADERS BLOCK LAYOUT:
<img width="1123" alt="Screen Shot 2022-06-09 at 7 50 13 AM" src="https://user-images.githubusercontent.com/64623209/172851030-91da755f-135b-4069-9787-03ebf2d9832c.png">


PW:
<img width="1258" alt="Screen Shot 2022-06-08 at 2 27 34 PM" src="https://user-images.githubusercontent.com/64623209/172702204-7d00b932-5714-4236-8fa4-58e35cf1a1e9.png">
PFW:
<img width="1083" alt="Screen Shot 2022-06-08 at 2 29 46 PM" src="https://user-images.githubusercontent.com/64623209/172702251-adba3a11-9f8d-4fe1-84f4-399e84ba4f21.png">
OEM:
<img width="1244" alt="Screen Shot 2022-06-08 at 2 31 35 PM" src="https://user-images.githubusercontent.com/64623209/172702288-aa72539e-5a09-4a0d-8c15-6746cb9b3929.png">
MUNDO:
<img width="1332" alt="Screen Shot 2022-06-08 at 2 33 25 PM" src="https://user-images.githubusercontent.com/64623209/172702346-3e85d72e-3024-4b44-83ac-473732a68946.png">
