### PR TITLE
Updated Contextual Companies in article video block

### DIFF
--- a/packages/theme-monorail-leaders/components/company-videos.marko
+++ b/packages/theme-monorail-leaders/components/company-videos.marko
@@ -14,32 +14,51 @@ $ const { contentId } = input;
     withSite: false,
   }
 >
-  <if(nodes.length)>
-    <for|company| of=nodes>
-      <if(company.isLeader)>
-        $ const linkAttrs = {
-          'data-company-id': company.id,
-          'data-company-name': company.name,
-        };
-        $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
-        <if(videos.length)>
-          <marko-web-node-list class="mt-block" collapsible=false>
-            <@header modifiers=["leadership-company-videos"]>
-              <span>${i18n("Videos from")} ${company.name}</span>
-              <marko-web-link target="_blank" href=get(company, "youtube.url") attrs=linkAttrs>
-                ${i18n("View all videos")}
-              </marko-web-link>
-            </@header>
-            <@body>
+$ const blockName = "content-card-deck";
+$ const modifiers = ["leaders"];
+
+<if(nodes.length)>
+  <for|company| of=nodes>
+    <if(company.isLeader)>
+      $ const linkAttrs = {
+        'data-company-id': company.id,
+        'data-company-name': company.name,
+      };
+      $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
+      <if(videos.length)>
+        <marko-web-block name=blockName modifiers=modifiers>
+          <marko-web-element block-name=blockName name="header">
+            <marko-web-element block-name=blockName name="header-left">
+              <marko-web-element block-name=blockName name="title">
+                ${i18n("Videos from")} ${company.name}
+              </marko-web-element>
+            </marko-web-element>
+            <marko-web-element block-name=blockName name="header-right">
+              <marko-web-element block-name=blockName name="view-more">
+                <marko-web-link href=get(company, "youtube.url")>
+                  ${i18n("View more")} &raquo;
+                </marko-web-link>
+              </marko-web-element>
+            </marko-web-element>
+          </marko-web-element>
+          <marko-web-element block-name=blockName name="body">
+            $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
+              <!-- @TODO: make this work with the standard content node from <theme-content-card-deck-flow> -->
+              <!-- Meaning ensure the unique youtube nodes are handled -->
               <marko-web-leaders-card-deck-flow cols=3 nodes=videos>
                 <@slot|{ node, index }|>
                   <marko-web-leaders-youtube-card-node company-id=company.id node=node link-attrs=linkAttrs />
                 </@slot>
               </marko-web-leaders-card-deck-flow>
-            </@body>
-          </marko-web-node-list>
-        </if>
+            <marko-web-element block-name=blockName name="view-more-bottom">
+              <marko-web-link href=get(company, "youtube.url")>
+                ${i18n("View more")} &raquo;
+              </marko-web-link>
+            </marko-web-element>
+          </marko-web-element>
+        </marko-web-block>
       </if>
-    </for>
-  </if>
+    </if>
+  </for>
+</if>
 </marko-web-query>

--- a/packages/theme-monorail-leaders/scss/components/_featured-companies.scss
+++ b/packages/theme-monorail-leaders/scss/components/_featured-companies.scss
@@ -1,4 +1,5 @@
 .leaders-featured-companies {
+  $self: &;
   margin-bottom: 24px;
 
   .node-list {
@@ -15,6 +16,42 @@
       border-right: 2px solid $gray-200;
       border-bottom: 2px solid $gray-200;
       border-radius: 0 0 4px 4px;
+    }
+  }
+}
+
+.content-card-deck {
+  $self: &;
+  &--leaders {
+    margin-bottom: map-get($spacers, block);
+
+    #{ $self }__header {
+      background-color: $primary;
+      border-radius: 4px 4px 0 0;
+      color: #fff;
+      padding: 12px;
+      margin-bottom: 0;
+      font-size: 18px;
+      #{ $self }__view-more a,
+      #{ $self }__view-more a:hover {
+        font-size: 12px;
+        color: $white;
+      }
+    }
+
+    #{ $self }__body {
+      border-left: 2px solid $gray-200;
+      border-right: 2px solid $gray-200;
+      border-bottom: 2px solid $gray-200;
+      border-radius: 0 0 4px 4px;
+    }
+
+    #{ $self }__view-more-bottom {
+      padding: map-get($spacers, block);
+    }
+
+    .card-deck-flow__node {
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
Update the structure to match the new section card deck block.  It is still using the custom youtube flow/nodes as the youtube nodes do not have the standard object structure.  Also added leaders specific css to style the section card dek block with the leaders style.

![Screen Shot 2022-06-13 at 9 12 16 AM](https://user-images.githubusercontent.com/3845869/173373300-2ab8ca45-9ef0-4706-929e-3c616ff4facb.png)

