### PR TITLE
Update Podcast Page Template and routing Automation World Global (Monorail) site.

### DIFF
--- a/packages/global/routes/scheduled-content.js
+++ b/packages/global/routes/scheduled-content.js
@@ -38,14 +38,6 @@ module.exports = (app) => {
         title: 'Videos',
       });
   });
-  app.get('/podcasts', (_, res) => {
-    res.marko(publishedContent,
-      {
-        alias: 'podcasts',
-        includeContentTypes: ['Podcast'],
-        title: 'Podcasts',
-      });
-  });
   app.get('/downloads', (_, res) => {
     res.marko(publishedContent,
       {

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -22,10 +22,10 @@ const defaultContentGatingHandler = require('./utils/content-gating-handler');
 const routes = (siteRoutes, siteConfig) => (app) => {
   // Handle submissions on /__inquiry
   loadInquiry(app);
-  // Shared/global routes (all sites)
-  sharedRoutes(app, siteConfig);
   // Load site routes
   siteRoutes(app);
+  // Shared/global routes (all sites)
+  sharedRoutes(app, siteConfig);
 };
 
 module.exports = (options = {}) => {

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -22,10 +22,10 @@ const defaultContentGatingHandler = require('./utils/content-gating-handler');
 const routes = (siteRoutes, siteConfig) => (app) => {
   // Handle submissions on /__inquiry
   loadInquiry(app);
-  // Load site routes
-  siteRoutes(app);
   // Shared/global routes (all sites)
   sharedRoutes(app, siteConfig);
+  // Load site routes
+  siteRoutes(app);
 };
 
 module.exports = (options = {}) => {

--- a/sites/global.automationworld.com/server/routes/website-section.js
+++ b/sites/global.automationworld.com/server/routes/website-section.js
@@ -3,11 +3,17 @@ const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/gra
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
+const podcasts = require('../templates/website-section/podcasts');
 
 module.exports = (app) => {
   app.get('/:alias(leaders)', withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
+  }));
+
+  app.get('/:alias(podcasts)', withWebsiteSection({
+    template: podcasts,
+    queryFragment,
   }));
 
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({

--- a/sites/global.automationworld.com/server/templates/website-section/podcasts.marko
+++ b/sites/global.automationworld.com/server/templates/website-section/podcasts.marko
@@ -1,0 +1,114 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import defaultDescription from "@parameter1/base-cms-marko-web/utils/published-content/description";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-list";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const sections = getAsArray(input, "sections");
+$ const queryName = defaultValue(input.queryName, "website-scheduled-content");
+$ const { config, GAM, pagination: p } = out.global;
+$ const alias = "podcasts";
+$ const title = "Podcasts";
+$ const includeContentTypes = ["Podcast"];
+$ const perPage = 18;
+
+$ const type = "scheduled-content";
+$ const description = defaultDescription(title, config);
+
+$ const queryParams = {
+  limit: 5,
+  requiresImage: true,
+  queryFragment,
+  sectionAlias: "podcasts"
+};
+
+<marko-web-query|{ nodes }| name=queryName params=queryParams>
+  $ const excludeContentIds = nodes.map((node) => node.id);
+  <theme-default-page name=title>
+    <@head>
+      <theme-section-feed-block|{ totalCount }| with-section=false query-name=queryName count-only=true>
+        <@query-params include-content-types=includeContentTypes exclude-content-ids=excludeContentIds />
+        <theme-pagination-controls
+          per-page=perPage
+          total-count=totalCount
+          path=`/${alias}`
+          as-rels=true
+        />
+      </theme-section-feed-block>
+      <marko-web-gtm-default-context|{ context }| type=type>
+        <marko-web-gtm-push data=context />
+      </marko-web-gtm-default-context>
+    </@head>
+    <@page>
+      <marko-web-page-wrapper>
+        <@section|{ aliases }| modifiers=["first"]>
+          <theme-gam-define-display-ad
+            name="leaderboard"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+          <theme-gam-wallpaper-ad aliases=aliases position="section_page" />
+        </@section>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-breadcrumbs-with-home>
+                <@item>${title}</@item>
+              </default-theme-breadcrumbs-with-home>
+              <h1 class="page-wrapper__title">${title}</h1>
+              <div class="page-wrapper__deck">${description}</div>
+            </div>
+          </div>
+        </@section>
+        <@section|{ aliases }|>
+          <if(p.page === 1)>
+            <theme-top-stories-block
+              with-header=false
+              lazyload=false
+              with-native-x=false
+              query-params={ sectionAlias: "podcasts"}
+            />
+          </if>
+        </@section>
+        <@section|{ blockName }|>
+          <theme-section-feed-block with-section=false query-name=queryName lazyload=false>
+            <@query-params
+              limit=18
+              skip=p.skip({ perPage })
+              query-fragment=queryFragment
+              include-content-types=includeContentTypes
+              exclude-content-ids=excludeContentIds
+            />
+          </theme-section-feed-block>
+          <theme-section-feed-block|{ totalCount }| query-name=queryName count-only=true>
+            <@query-params include-content-types=includeContentTypes exclude-content-ids=excludeContentIds />
+            <theme-pagination-controls
+              per-page=perPage
+              total-count=totalCount
+              path=`/${alias}`
+            />
+          </theme-section-feed-block>
+        </@section>
+        <@section|{ aliases }|>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
+        <@section>
+          <theme-client-side-most-popular-block />
+        </@section>
+        <@section|{ aliases }|>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
+      </marko-web-page-wrapper>
+    </@page>
+  </theme-default-page>
+</marko-web-query>

--- a/sites/global.automationworld.com/server/templates/website-section/podcasts.marko
+++ b/sites/global.automationworld.com/server/templates/website-section/podcasts.marko
@@ -18,7 +18,7 @@ $ const queryParams = {
   limit: 5,
   requiresImage: true,
   queryFragment,
-  sectionAlias: "podcasts"
+  sectionAlias: "podcasts/aw-podcasts"
 };
 
 <marko-web-query|{ nodes }| name=queryName params=queryParams>
@@ -66,7 +66,7 @@ $ const queryParams = {
               with-header=false
               lazyload=false
               with-native-x=false
-              query-params={ sectionAlias: "podcasts"}
+              query-params={ sectionAlias: "podcasts/aw-podcasts"}
             />
           </if>
         </@section>

--- a/sites/global.healthcarepackaging.com/server/routes/scheduled-content.js
+++ b/sites/global.healthcarepackaging.com/server/routes/scheduled-content.js
@@ -9,4 +9,12 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
+  app.get('/podcasts', (_, res) => {
+    res.marko(scheduledContent,
+      {
+        alias: 'podcasts',
+        includeContentTypes: ['Podcast'],
+        title: 'Podcasts',
+      });
+  });
 };

--- a/sites/global.mundopmmi.com/server/routes/scheduled-content.js
+++ b/sites/global.mundopmmi.com/server/routes/scheduled-content.js
@@ -12,4 +12,12 @@ module.exports = (app) => {
         endingAfter: (new Date()).valueOf(),
       });
   });
+  app.get('/podcasts', (_, res) => {
+    res.marko(scheduledContent,
+      {
+        alias: 'podcasts',
+        includeContentTypes: ['Podcast'],
+        title: 'Podcasts',
+      });
+  });
 };

--- a/sites/global.oemmagazine.org/server/routes/index.js
+++ b/sites/global.oemmagazine.org/server/routes/index.js
@@ -1,9 +1,13 @@
 const home = require('./home');
+const scheduledContent = require('./scheduled-content');
 const websiteSection = require('./website-section');
 
 module.exports = (app) => {
   // Homepage
   home(app);
+
+  // Scheduled Content
+  scheduledContent(app);
 
   // Website Sections
   websiteSection(app);

--- a/sites/global.oemmagazine.org/server/routes/scheduled-content.js
+++ b/sites/global.oemmagazine.org/server/routes/scheduled-content.js
@@ -1,0 +1,12 @@
+const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+
+module.exports = (app) => {
+  app.get('/podcasts', (_, res) => {
+    res.marko(scheduledContent,
+      {
+        alias: 'podcasts',
+        includeContentTypes: ['Podcast'],
+        title: 'Podcasts',
+      });
+  });
+};

--- a/sites/global.packworld.com/server/routes/scheduled-content.js
+++ b/sites/global.packworld.com/server/routes/scheduled-content.js
@@ -9,4 +9,12 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
+  app.get('/podcasts', (_, res) => {
+    res.marko(scheduledContent,
+      {
+        alias: 'podcasts',
+        includeContentTypes: ['Podcast'],
+        title: 'Podcasts',
+      });
+  });
 };

--- a/sites/global.profoodworld.com/server/routes/scheduled-content.js
+++ b/sites/global.profoodworld.com/server/routes/scheduled-content.js
@@ -9,4 +9,12 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
+  app.get('/podcasts', (_, res) => {
+    res.marko(scheduledContent,
+      {
+        alias: 'podcasts',
+        includeContentTypes: ['Podcast'],
+        title: 'Podcasts',
+      });
+  });
 };


### PR DESCRIPTION
Hero block only displays  on the first page of results

![Podcasts](https://user-images.githubusercontent.com/46794001/174664115-1aa05887-4722-430f-b687-45ce4cb8a0bc.png)


NOTE: Items will need to be scheduled to the new AW Podcasts section in order for this page to work.