### PR TITLE
Add boolean questions label to profile page

### DIFF
--- a/packages/global/config/identity-x.js
+++ b/packages/global/config/identity-x.js
@@ -5,6 +5,7 @@ module.exports = ({
   appId,
   requiredServerFields,
   requiredClientFields,
+  booleanQuestionsLabel = 'Choose your subscriptions: ',
   ...rest
 } = {}) => {
   const config = new IdentityXConfiguration({
@@ -12,6 +13,7 @@ module.exports = ({
     apiToken: process.env.IDENTITYX_API_TOKEN,
     requiredServerFields,
     requiredClientFields,
+    booleanQuestionsLabel,
     onHookError: newrelic.noticeError.bind(newrelic),
     ...rest,
   });

--- a/sites/global.mundopmmi.com/config/identity-x.js
+++ b/sites/global.mundopmmi.com/config/identity-x.js
@@ -1,5 +1,6 @@
 const configureIdentityX = require('@pmmi-media-group/package-global/config/identity-x');
 
 module.exports = configureIdentityX({
+  booleanQuestionsLabel: 'Elige tus suscripciones: ',
   appId: process.env.IDENTITYX_APP_ID || '5e28a4c858e67b86c955ae4d',
 });


### PR DESCRIPTION
 - [ ] Requires https://github.com/parameter1/base-cms/pull/373 to be merged and a @parameter1/base-cms dep upgrade.
Add global idx boolean questions label & set translated version in mundo specifically.
<img width="1176" alt="Screen Shot 2022-07-11 at 11 12 01 AM" src="https://user-images.githubusercontent.com/3845869/178314893-b993ba93-46b4-48c6-b2d3-c700b701da3e.png">
<img width="1203" alt="Screen Shot 2022-07-11 at 11 12 11 AM" src="https://user-images.githubusercontent.com/3845869/178314903-dda070d8-d1db-4770-96c6-6544aab1c988.png">

