### PR TITLE
Setup nativeX announcement placement & dynamic site-menu positioner. 

### DIFF
--- a/packages/global/browser/dynamic-site-menu-positioner.vue
+++ b/packages/global/browser/dynamic-site-menu-positioner.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="site-menu-listener" />
+</template>
+
+<script>
+import EventBus from '@parameter1/base-cms-marko-web/browser/event-bus';
+
+export default {
+  created() {
+    EventBus.$on('site-menu-expanded', (expanded) => {
+      if (expanded) {
+        const header = document.getElementsByClassName('site-header')[0];
+        const menu = document.getElementsByClassName('site-menu')[0];
+        menu.style.top = `${header.offsetTop + header.offsetHeight}px`;
+      }
+    });
+  },
+};
+</script>

--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,10 +2,12 @@ import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 import MonoRailLeaders from '@pmmi-media-group/package-theme-monorail-leaders/browser';
 
 const ImageSlider = () => import(/* webpackChunkName: "global-image-slider" */ './image-slider.vue');
+const DynamicSiteMenuPositioner = () => import(/* webpackChunkName: "dynamic-site-menu-positioner" */ './dynamic-site-menu-positioner.vue');
 
 export default (Browser) => {
   MonoRail(Browser);
   MonoRailLeaders(Browser);
 
+  Browser.register('DynamicSiteMenuPositioner', DynamicSiteMenuPositioner);
   Browser.register('GlobalImageSlider', ImageSlider);
 };

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -13,6 +13,9 @@
       "required": true
     }
   },
+  "<global-native-x-announcement-block>": {
+    "template": "./native-x-announcement.marko"
+  },
   "<global-native-x-list-block>": {
     "template": "./native-x-list.marko"
   },

--- a/packages/global/components/blocks/native-x-announcement.marko
+++ b/packages/global/components/blocks/native-x-announcement.marko
@@ -1,0 +1,32 @@
+$ const { nativeX: nxConfig } = out.global;
+$ const name = input.placementName ? input.placementName : "announcement";
+$ const aliases = input.aliases ? input.aliases : [];
+$ const blockName = "announcement";
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name, aliases });
+
+<if(uri && placement && placement.id)>
+  <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
+    $ const hasAd = ads && ads.length && ads[0] && ads[0].hasCampaign;
+    <if(hasAd)>
+      $ const { attributes: attrs, creative, href } = ads[0];
+      $ const { title, teaser, linkText } = creative;
+
+      <marko-web-block name=blockName>
+        <marko-web-link href=href attrs=attrs.link  >
+          <marko-web-element block-name=blockName name="wrapper" attrs=attrs.container >
+            <marko-web-element block-name=blockName name="short-title">
+              ${title.substring(0, 60)}
+            </marko-web-element>
+            <marko-web-element block-name=blockName name="title">
+              ${teaser.substring(0, 100)}
+            </marko-web-element>
+            <marko-web-element block-name=blockName name="cta">
+              ${linkText}
+            </marko-web-element>
+          </marko-web-element>
+        </marko-web-link>
+      </marko-web-block>
+    </if>
+  </marko-web-native-x-fetch-elements>
+</if>

--- a/packages/global/components/blocks/native-x-announcement.marko
+++ b/packages/global/components/blocks/native-x-announcement.marko
@@ -4,8 +4,6 @@ $ const aliases = input.aliases ? input.aliases : [];
 $ const blockName = "announcement";
 $ const uri = nxConfig.getUri();
 $ const placement = nxConfig.getPlacement({ name, aliases });
-$ const titleLength = input.titleLength ? input.titleLength : 100;
-$ const shortTitleLength = input.shortTitleLength ? input.shortTitleLength : 60;
 
 <if(uri && placement && placement.id)>
   <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
@@ -18,10 +16,10 @@ $ const shortTitleLength = input.shortTitleLength ? input.shortTitleLength : 60;
         <marko-web-link href=href attrs=attrs.link  >
           <marko-web-element block-name=blockName name="wrapper" attrs=attrs.container >
             <marko-web-element block-name=blockName name="short-title">
-              ${title.substring(0, shortTitleLength)}<if(title.length > shortTitleLength)>&#8230;</if>
+              ${title}
             </marko-web-element>
             <marko-web-element block-name=blockName name="title">
-              ${teaser.substring(0, titleLength)}<if(teaser.length > titleLength)>&#8230;</if>
+              ${teaser}
             </marko-web-element>
             <marko-web-element block-name=blockName name="cta">
               ${linkText}

--- a/packages/global/components/blocks/native-x-announcement.marko
+++ b/packages/global/components/blocks/native-x-announcement.marko
@@ -4,6 +4,8 @@ $ const aliases = input.aliases ? input.aliases : [];
 $ const blockName = "announcement";
 $ const uri = nxConfig.getUri();
 $ const placement = nxConfig.getPlacement({ name, aliases });
+$ const titleLength = input.titleLength ? input.titleLength : 100;
+$ const shortTitleLength = input.shortTitleLength ? input.shortTitleLength : 60;
 
 <if(uri && placement && placement.id)>
   <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
@@ -16,10 +18,10 @@ $ const placement = nxConfig.getPlacement({ name, aliases });
         <marko-web-link href=href attrs=attrs.link  >
           <marko-web-element block-name=blockName name="wrapper" attrs=attrs.container >
             <marko-web-element block-name=blockName name="short-title">
-              ${title.substring(0, 60)}
+              ${title.substring(0, shortTitleLength)}<if(title.length > shortTitleLength)>&#8230;</if>
             </marko-web-element>
             <marko-web-element block-name=blockName name="title">
-              ${teaser.substring(0, 100)}
+              ${teaser.substring(0, titleLength)}<if(teaser.length > titleLength)>&#8230;</if>
             </marko-web-element>
             <marko-web-element block-name=blockName name="cta">
               ${linkText}

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -89,6 +89,7 @@ $ const buttonLabels = { continue: continueLabel };
       on="newsletter-form-subscription"
       clear-data=true
     />
+    <global-native-x-announcement-block placement-name="default" />
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
       <theme-site-header
         has-user=hasUser
@@ -101,6 +102,7 @@ $ const buttonLabels = { continue: continueLabel };
       />
       <global-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
+    <marko-web-browser-component name="DynamicSiteMenuPositioner" />
     <${input.aboveContainer} />
   </@above-container>
   <@below-container>

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -89,7 +89,7 @@ $ const buttonLabels = { continue: continueLabel };
       on="newsletter-form-subscription"
       clear-data=true
     />
-    <global-native-x-announcement-block placement-name="default" />
+    <global-native-x-announcement-block />
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
       <theme-site-header
         has-user=hasUser

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -11,13 +11,13 @@
     margin: map-get($spacers, 2) auto;
     margin-left: auto;
     margin-right: auto;
-    a,
-    a:hover {
-      text-decoration: none;
-    }
     @media (max-width: $marko-web-document-container-max-width) {
       padding: 0 ($marko-web-page-wrapper-padding * 2);
     }
+  }
+  a,
+  a:hover {
+    text-decoration: none;
   }
   &__title,
   &__short-title,

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -7,6 +7,7 @@
   &__wrapper {
     display: flex;
     flex-direction: row;
+    justify-content: center;
     max-width: $marko-web-document-container-max-width;
     margin: map-get($spacers, 2) auto;
     margin-left: auto;

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -1,0 +1,39 @@
+.announcement {
+  z-index: 15000;
+  background-color: $primary;
+  border-bottom: 1px solid #c4c6cb;
+  font-weight: $font-weight-bold;
+  font-size: 12px;
+  &__wrapper {
+    display: flex;
+    flex-direction: row;
+    max-width: $marko-web-document-container-max-width;
+    margin: map-get($spacers, 2) auto;
+    padding: 0 $marko-web-page-wrapper-padding;
+  }
+  &__title,
+  &__short-title,
+  &__cta {
+    font-size: 12px;
+    font-weight: 700;
+    height: 20px;
+    letter-spacing: 0.3px;
+    line-height: 20px;
+  }
+  &__short-title {
+    color: $white;
+    @media (min-width: 728px) {
+      display: none;
+    }
+  }
+  &__title {
+    color: $white;
+    @media (max-width: 728px) {
+      display: none;
+    }
+  }
+  &__cta {
+    color: $white;
+    margin-left: 1em;
+  }
+}

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -9,9 +9,15 @@
     flex-direction: row;
     max-width: $marko-web-document-container-max-width;
     margin: map-get($spacers, 2) auto;
-    padding: 0 $marko-web-page-wrapper-padding;
-    max-width: 100%;
-    overflow: hidden;
+    margin-left: auto;
+    margin-right: auto;
+    a,
+    a:hover {
+      text-decoration: none;
+    }
+    @media (max-width: $marko-web-document-container-max-width) {
+      padding: 0 ($marko-web-page-wrapper-padding * 2);
+    }
   }
   &__title,
   &__short-title,
@@ -28,12 +34,18 @@
     @media (min-width: 728px) {
       display: none;
     }
+    max-width: 75ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   &__title {
     color: $white;
     @media (max-width: 728px) {
       display: none;
     }
+    max-width: 150ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   &__cta {
     color: $white;

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -10,6 +10,8 @@
     max-width: $marko-web-document-container-max-width;
     margin: map-get($spacers, 2) auto;
     padding: 0 $marko-web-page-wrapper-padding;
+    max-width: 100%;
+    overflow: hidden;
   }
   &__title,
   &__short-title,
@@ -19,6 +21,7 @@
     height: 20px;
     letter-spacing: 0.3px;
     line-height: 20px;
+    white-space: nowrap;
   }
   &__short-title {
     color: $white;

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -14,6 +14,7 @@
 @import "./components/content-card-list";
 @import "./components/leaders";
 @import "./components/native-x-list";
+@import "./components/native-x-announcement";
 
 // @import "../components/magazine/scss/index";
 
@@ -253,5 +254,11 @@ label {
       margin-top: 30px;
       margin-bottom: 30px;
     }
+  }
+}
+
+.site-header .search-sponsor__logo {
+  @media (max-width: 420px) {
+    display: none;
   }
 }


### PR DESCRIPTION
Working Example:
<img width="411" alt="Screen Shot 2022-07-26 at 1 52 07 PM" src="https://user-images.githubusercontent.com/3845869/181088500-a933b24a-4218-4810-bccb-ae44e1174409.png">
<img width="1250" alt="Screen Shot 2022-07-26 at 1 52 24 PM" src="https://user-images.githubusercontent.com/3845869/181088515-2ffdfc58-8e5b-447a-a4d2-80c07daf1676.png">



### Examples with truncation working:
<img width="373" alt="Screen Shot 2022-07-26 at 8 58 35 AM" src="https://user-images.githubusercontent.com/3845869/181025108-e3c67907-d329-43ef-b07f-1a4f52804bcb.png">
<img width="609" alt="Screen Shot 2022-07-26 at 8 58 44 AM" src="https://user-images.githubusercontent.com/3845869/181025132-ebc79101-f311-4148-a502-5cadd3999c99.png">
<img width="914" alt="Screen Shot 2022-07-26 at 8 58 55 AM" src="https://user-images.githubusercontent.com/3845869/181025141-303c3cfc-715c-4162-9849-a799b08d40fa.png">
<img width="1252" alt="Screen Shot 2022-07-26 at 8 59 05 AM" src="https://user-images.githubusercontent.com/3845869/181025147-c0d9e757-9c71-464e-9987-c94ca4b2aabf.png">
