### PR TITLE
Add translation support to scheduled content pages

### DIFF
--- a/packages/global/components/layouts/scheduled-content/index.marko
+++ b/packages/global/components/layouts/scheduled-content/index.marko
@@ -5,7 +5,7 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const sections = getAsArray(input, "sections");
 $ const queryName = defaultValue(input.queryName, "website-scheduled-content");
-$ const { config, GAM, pagination: p } = out.global;
+$ const { config, GAM, pagination: p, i18n } = out.global;
 $ const {
   alias,
   title,
@@ -49,10 +49,10 @@ $ const description = defaultDescription(title, config);
         <div class="row">
           <div class="col">
             <default-theme-breadcrumbs-with-home>
-              <@item>${title}</@item>
+              <@item>${i18n(title)}</@item>
             </default-theme-breadcrumbs-with-home>
-            <h1 class="page-wrapper__title">${title}</h1>
-            <div class="page-wrapper__deck">${description}</div>
+            <h1 class="page-wrapper__title">${i18n(title)}</h1>
+            <div class="page-wrapper__deck">${i18n(description)}</div>
           </div>
         </div>
       </@section>

--- a/sites/global.mundopmmi.com/config/i18n.js
+++ b/sites/global.mundopmmi.com/config/i18n.js
@@ -29,6 +29,7 @@ module.exports = {
   'company overview': 'Compañía Resumen',
   'featured products': 'Productos presentados',
   downloads: 'Recursos Digitales',
+  'the latest downloads from mundo pmmi': 'Las últimas descargas de Mundo PMMI',
   'previous page': 'Pagina Anterior',
   page: 'Pagina',
   of: 'de',


### PR DESCRIPTION
Add i18n translation to breadcrumb, title & description on scheduled content layout templates

Also add i18n translation for downloads description to Mundo’s i18n config.
<img width="1244" alt="Screen Shot 2022-08-01 at 9 48 59 AM" src="https://user-images.githubusercontent.com/3845869/182177519-3f458323-4040-4262-a089-fc8691ec12be.png">

