### PR TITLE
Realias "Issues" to "News" (Do not change labels on current theme sites)

### DIFF
--- a/sites/global.healthcarepackaging.com/config/navigation.js
+++ b/sites/global.healthcarepackaging.com/config/navigation.js
@@ -43,7 +43,7 @@ const desktopMenu = {
   middleCol: {
     items: [
       ...topics,
-      { href: '/issues', label: 'News' },
+      { href: '/news', label: 'News' },
     ],
   },
   rightCol: {
@@ -92,7 +92,7 @@ module.exports = {
     ],
     topics: [
       ...topics,
-      { href: '/issues', label: 'News' },
+      { href: '/news', label: 'News' },
     ],
     more: [
       subscribe,

--- a/sites/global.packworld.com/config/navigation.js
+++ b/sites/global.packworld.com/config/navigation.js
@@ -4,7 +4,7 @@ const subscribe = require('./subscribe');
 const topics = [
   { href: '/machinery', label: 'Machinery' },
   { href: '/design', label: 'Design' },
-  { href: '/issues', label: 'News' },
+  { href: '/news', label: 'News' },
 ];
 
 const resources = [

--- a/sites/global.packworld.com/server/templates/index.marko
+++ b/sites/global.packworld.com/server/templates/index.marko
@@ -22,7 +22,7 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <theme-section-list-deck-block aliases=["machinery", "design", "issues"] />
+    <theme-section-list-deck-block aliases=["machinery", "design", "news"] />
   </@section>
 
   <@section|{ aliases }|>

--- a/sites/healthcarepackaging.com/config/navigation.js
+++ b/sites/healthcarepackaging.com/config/navigation.js
@@ -31,7 +31,7 @@ module.exports = {
         { href: '/machinery-materials', label: 'Machinery & Materials' },
         { href: '/markets', label: 'Markets' },
         { href: '/logistics-distribution', label: 'Logistics & Cold Chain' },
-        { href: '/issues', label: 'Issues' },
+        { href: '/news', label: 'Issues' },
       ],
     },
     {

--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -115,11 +115,11 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ sectionAlias: "issues", limit: 4, queryFragment }
+          params={ sectionAlias: "news", limit: 4, queryFragment }
         >
           <shared-content-list-flow nodes=nodes>
             <@header>
-              <marko-web-link href="/issues">Issues</marko-web-link>
+              <marko-web-link href="/news">Issues</marko-web-link>
             </@header>
           </shared-content-list-flow>
         </marko-web-query>

--- a/sites/packworld.com/config/navigation.js
+++ b/sites/packworld.com/config/navigation.js
@@ -30,7 +30,7 @@ module.exports = {
       items: [
         { href: '/machinery', label: 'Machinery' },
         { href: '/design', label: 'Design' },
-        { href: '/issues', label: 'Issues' },
+        { href: '/news', label: 'Issues' },
       ],
     },
     {

--- a/sites/packworld.com/server/templates/index.marko
+++ b/sites/packworld.com/server/templates/index.marko
@@ -97,7 +97,7 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ sectionAlias: "issues", limit: 4, queryFragment }
+          params={ sectionAlias: "news", limit: 4, queryFragment }
         >
           <shared-content-list-flow nodes=nodes>
             <@header>


### PR DESCRIPTION
![monorail-pw-homepage](https://user-images.githubusercontent.com/46794001/182177477-479ea8e0-6b2d-466e-95c3-f413a1ccd29a.png)


This is causing erroring on the current live versions of PW and HCP due to an alias change from news to section (they are loading these sections as blocks on their homepage) as well as on the Monorail version of PW for the same reason. I opted not to change the Labels on the existing sites navigation's but changed the aliasing of where they go so as to opt for not redirecting to the News section.