### PR TITLE
FIx /leaders pages on global theme

### DIFF
--- a/packages/global/components/layouts/website-section/leaders.marko
+++ b/packages/global/components/layouts/website-section/leaders.marko
@@ -54,7 +54,7 @@ $ const { GAM, site, config } = out.global;
             </div>
           </div>
         </@section>
-        <@section|{ alias }| modifiers=["break-container"]>
+        <@section|{ alias }| modifiers=["leaders-full-width"]>
           <global-leaders-all />
         </@section>
 

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -10,6 +10,8 @@
   },
   "<global-website-section-leaders-layout>": {
     "template": "./leaders.marko",
+    "<page-description>": {},
+    "<page-body>": {},
     "<head>": {},
     "@sections <section>[]": {},
     "@id": "number",

--- a/packages/global/scss/components/_leaders.scss
+++ b/packages/global/scss/components/_leaders.scss
@@ -89,3 +89,15 @@
     }
   }
 }
+
+.page-wrapper {
+  &__section {
+    &--leaders-full-width {
+      .leaders {
+        &--all {
+          max-width: $marko-web-document-container-max-width;
+        }
+      }
+    }
+  }
+}

--- a/sites/global.automationworld.com/server/templates/website-section/leaders.marko
+++ b/sites/global.automationworld.com/server/templates/website-section/leaders.marko
@@ -2,11 +2,20 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
 
-$ const { site } = out.global;
+$ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+  <@page-description>
+    <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+  </@page-description>
+  <@page-body>
+    <p>Recognize innovation, leadership and excellence among suppliers of automation software, technology and products.</p>
+    <p>Read the <em>Automation World</em> feature article to see all the <a href="/21232623">2021 First Team Honorees</a>.</p>
+    <p><em>Thanks for your participation, which promotes excellence within the automation community!</em></p>
+  </@page-body>
+</global-website-section-leaders-layout>

--- a/sites/global.healthcarepackaging.com/server/templates/website-section/leaders.marko
+++ b/sites/global.healthcarepackaging.com/server/templates/website-section/leaders.marko
@@ -2,11 +2,15 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
 
-$ const { site } = out.global;
+$ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+  <@page-description>
+    <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+  </@page-description>
+</global-website-section-leaders-layout>

--- a/sites/global.mundopmmi.com/server/templates/website-section/leaders.marko
+++ b/sites/global.mundopmmi.com/server/templates/website-section/leaders.marko
@@ -9,4 +9,11 @@ $ const { site } = out.global;
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+ <@page-description>
+    <p>Bienvenido al programa ${site.get("leaders.title")} de Mundo PMMI.</p>
+  </@page-description>
+  <@page-body>
+    <p>Esperamos que encuentre útiles los recursos de este directorio de proveedores de maquinaria para empaque y materiales. Para cada proveedor participante, usted encontrará una página de perfil muy completa diseñada para ayudarle a tomar decisiones mejor informadas. </p>
+  </@page-body>
+</global-website-section-leaders-layout>

--- a/sites/global.oemmagazine.org/server/templates/website-section/leaders.marko
+++ b/sites/global.oemmagazine.org/server/templates/website-section/leaders.marko
@@ -2,11 +2,15 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
 
-$ const { site } = out.global;
+$ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+  <@page-description>
+    <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+  </@page-description>
+</global-website-section-leaders-layout>

--- a/sites/global.packworld.com/server/templates/website-section/leaders.marko
+++ b/sites/global.packworld.com/server/templates/website-section/leaders.marko
@@ -2,11 +2,19 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
 
-$ const { site } = out.global;
+$ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+  <@page-description>
+    <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+  </@page-description>
+  <@page-body>
+    <p>You'll be pleased to know that our annual Leaders in Packaging program also supports packaging education via a tuition scholarship for students pursuing degrees that will prepare them for a career in packaging. The annual <a href="https://www.packworld.com/page/future-leaders-packaging-scholarship">Future Leaders in Packaging Scholarship</a> has been awarded to students at Clemson University, Missouri University of Science and Technology, Virginia Tech, Michigan State and <a href="https://www.alextech.edu/programs/mechatronics">Alexandria Technical and Community College Mechatronics</a>. 2022 will be our 12th year of supporting education with this scholarship. For more information, please contact Publisher Joe Angel at <a href="mailto:jangel@pmmimediagroup.com">jangel@pmmimediagroup.com</a>.</p><br>
+    <p><a href="https://pmg-production.s3.amazonaws.com/2022/PW/Files/LIP2022_MiniDirectory.pdf?utm=PWLeadersPage_MD" target="_blank" rel="noopener">Click here</a> to explore our new, easy-to-use condensed Leaders in Packaging directory where you can find top packaging machinery suppliers for any application. Organized by category, and updated monthly, you’ll easily find the packaging technology solution you require, be it case packing, palletizing, cartoning, or load stabilization.</p>
+  </@page-body>
+</global-website-section-leaders-layout>

--- a/sites/global.profoodworld.com/server/templates/website-section/leaders.marko
+++ b/sites/global.profoodworld.com/server/templates/website-section/leaders.marko
@@ -2,11 +2,15 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
 
-$ const { site } = out.global;
+$ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
   name=name
   page-node=pageNode
-/>
+>
+  <@page-description>
+    <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+  </@page-description>
+</global-website-section-leaders-layout>


### PR DESCRIPTION
- Add the page-description & page-body props to marko.json.  
- Port these site specific props template props to the global theme.
- update leaders page css to be full width with white background
<img width="787" alt="Screen Shot 2022-08-01 at 10 22 42 AM" src="https://user-images.githubusercontent.com/3845869/182184610-d02dbdc9-e709-41b7-8eda-720bc03f212e.png">
<img width="985" alt="Screen Shot 2022-08-01 at 10 27 45 AM" src="https://user-images.githubusercontent.com/3845869/182184620-cbd1581e-38a8-4b77-b622-c34bcee3b214.png">

