### PR TITLE
Replace ‘Eventos’ with ‘Suscribase’ in nav bar

### DIFF
--- a/sites/mundopmmi.com/config/navigation.js
+++ b/sites/mundopmmi.com/config/navigation.js
@@ -56,8 +56,8 @@ module.exports = {
   },
   secondary: {
     items: [
+      { href: 'https://mundopmmi.dragonforms.com/perspectivas?pk=Mundo_NL_Nav', label: 'Suscríbase', target: '_blank' },
       ...topics,
-      { href: '/eventos', label: 'Eventos' },
       { href: '/downloads', label: 'Recursos Digitales' },
       { href: '/leaders', label: 'Líderes' },
     ],


### PR DESCRIPTION
<img width="1213" alt="Screen Shot 2022-08-02 at 10 37 21 AM" src="https://user-images.githubusercontent.com/64623209/182415041-c78b050e-27b5-42bf-9e35-c9bd06dd59e2.png">
