### PR TITLE
Add login-email-placeholder to webinar & mundo

### DIFF
--- a/packages/global/components/layouts/content/webinar.marko
+++ b/packages/global/components/layouts/content/webinar.marko
@@ -98,7 +98,11 @@ $ const buttonLabels = { continue: continueLabel };
 
             <marko-web-identity-x-context|{ hasUser }|>
               <if(!hasUser)>
-                <identity-x-newsletter-form-inline button-labels=buttonLabels login-email-label=loginEmailLabel />
+                <identity-x-newsletter-form-inline
+                  button-labels=buttonLabels
+                  login-email-label=loginEmailLabel
+                  login-email-placeholder="example@yourcompany.com"
+                />
               </if>
             </marko-web-identity-x-context>
           </else>

--- a/sites/mundopmmi.com/server/templates/index.marko
+++ b/sites/mundopmmi.com/server/templates/index.marko
@@ -70,7 +70,11 @@ $ const buttonLabels = { continue: continueLabel };
   <@section>
     <marko-web-identity-x-context|{ hasUser }|>
       <if(!hasUser)>
-        <identity-x-newsletter-form-inline button-labels=buttonLabels, login-email-label=loginEmailLabel />
+        <identity-x-newsletter-form-inline
+          button-labels=buttonLabels
+          login-email-label=loginEmailLabel
+          login-email-placeholder="example@yourcompany.com"
+        />
       </if>
     </marko-web-identity-x-context>
   </@section>


### PR DESCRIPTION
<img width="1286" alt="Screen Shot 2022-08-03 at 3 20 52 PM" src="https://user-images.githubusercontent.com/64623209/182703442-90cc173d-b432-4182-9256-df71549109d4.png">
