### PR TITLE
Update newsletterState middleware configuration & how it is being included

### DIFF
--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -1,16 +1,59 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
 const { get } = require('@parameter1/base-cms-object-path');
+const gql = require('graphql-tag');
+
+// Content is currently gated by reg fragment
+const query = gql`
+  query content($input: ContentQueryInput!) {
+    content(input: $input){
+      id
+      type
+      userRegistration {
+        isCurrentlyRequired
+      }
+    }
+  }
+`;
+
+/**
+ * @param {object} req The Express request object.
+ */
+async function getContent(req) {
+  const { apollo, params } = req;
+  const id = Number(params.id);
+  const variables = { input: { id } };
+  const { data } = await apollo.query({ query, variables });
+  const { content } = data;
+  return content;
+}
 
 const cookieName = 'enlPrompted';
 
-module.exports = () => (req, res, next) => {
+module.exports = () => asyncRoute(async (req, res, next) => {
+  let disableGate = false;
+  // check if there is a content id in the request
+  const contentRegex = new RegExp(/\d{8}/, 'i');
+  const isContent = contentRegex.test(req.params.id);
+  const config = req.app.locals.site.getAsObject('newsletterState') || {};
+  // If there is a content id see if it is a gated piece of content
+  if (isContent) {
+    if (config.excludeGatedContent
+      || (config.excludeContentTypes && config.excludeContentTypes.length !== 0)
+    ) {
+      const content = await getContent(req);
+      const gatedContent = get(content, 'userRegistration.isCurrentlyRequired') || false;
+      const isExcludedByType = config.excludeContentTypes.includes(content.type);
+      disableGate = gatedContent || isExcludedByType;
+    }
+  }
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const initiallyExpanded = !(hasCookie || fromEmail || disabled);
+  const initiallyExpanded = !disableGate && !(hasCookie || fromEmail || disabled);
 
-  if (!hasCookie) {
+  if (initiallyExpanded) {
     // Expire in 14 days (2yr if already signed up)
     const days = fromEmail ? 365 * 2 : 14;
     const maxAge = days * 24 * 60 * 60 * 1000;
@@ -19,4 +62,4 @@ module.exports = () => (req, res, next) => {
 
   res.locals.newsletterState = { hasCookie, fromEmail, initiallyExpanded };
   next();
-};
+});

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -28,6 +28,7 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
 };
 
 const formatContentResponse = ({ res, content }) => {
+  if (!res.locals.newsletterState) return;
   const {
     initiallyExpanded,
     hasCookie,

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -1,8 +1,7 @@
 const { get } = require('@parameter1/base-cms-object-path');
 
 const cookieName = 'enlPrompted';
-
-module.exports = ({ setCookie = true } = {}) => (req, res, next) => {
+const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
@@ -26,4 +25,26 @@ module.exports = ({ setCookie = true } = {}) => (req, res, next) => {
     cookie: { name: cookieName, maxAge },
   };
   next();
+};
+
+const formatContentResponse = ({ res, content }) => {
+  const {
+    initiallyExpanded,
+    hasCookie,
+    fromEmail,
+    disabled,
+    cookie,
+  } = res.locals.newsletterState;
+
+  if (get(content, 'userRegistration.isCurrentlyRequired') === true) {
+    res.locals.newsletterState.initiallyExpanded = false;
+  } else if (!initiallyExpanded && !hasCookie && !disabled && !fromEmail) {
+    res.cookie(cookie.name, true, { maxAge: cookie.maxAge });
+    res.locals.newsletterState.initiallyExpanded = true;
+  }
+};
+
+module.exports = {
+  newsletterState,
+  formatContentResponse,
 };

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -34,7 +34,13 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   // check if there is a content id in the request
   const contentRegex = new RegExp(/\d{8}/, 'i');
   const isContent = contentRegex.test(req.params.id);
-  const config = req.app.locals.site.getAsObject('newsletterState') || {};
+  // Only setting this up this way for future use to override from a config elsewhere
+  const config = {
+    excludeGatedContent: true,
+    excludeContentTypes: [
+      'page',
+    ],
+  };
   // If there is a content id see if it is a gated piece of content
   if (isContent) {
     if (config.excludeGatedContent

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -1,71 +1,29 @@
-const { asyncRoute } = require('@parameter1/base-cms-utils');
 const { get } = require('@parameter1/base-cms-object-path');
-const gql = require('graphql-tag');
-
-// Content is currently gated by reg fragment
-const query = gql`
-  query content($input: ContentQueryInput!) {
-    content(input: $input){
-      id
-      type
-      userRegistration {
-        isCurrentlyRequired
-      }
-    }
-  }
-`;
-
-/**
- * @param {object} req The Express request object.
- */
-async function getContent(req) {
-  const { apollo, params } = req;
-  const id = Number(params.id);
-  const variables = { input: { id } };
-  const { data } = await apollo.query({ query, variables });
-  const { content } = data;
-  return content;
-}
 
 const cookieName = 'enlPrompted';
 
-module.exports = () => asyncRoute(async (req, res, next) => {
-  let disableGate = false;
-  // check if there is a content id in the request
-  const contentRegex = new RegExp(/\d{8}/, 'i');
-  const isContent = contentRegex.test(req.params.id);
-  // Only setting this up this way for future use to override from a config elsewhere
-  const config = {
-    excludeGatedContent: true,
-    excludeContentTypes: [
-      'page',
-    ],
-  };
-  // If there is a content id see if it is a gated piece of content
-  if (isContent) {
-    if (config.excludeGatedContent
-      || (config.excludeContentTypes && config.excludeContentTypes.length !== 0)
-    ) {
-      const content = await getContent(req);
-      const gatedContent = get(content, 'userRegistration.isCurrentlyRequired') || false;
-      const isExcludedByType = config.excludeContentTypes.includes(content.type);
-      disableGate = gatedContent || isExcludedByType;
-    }
-  }
+module.exports = ({ setCookie = true } = {}) => (req, res, next) => {
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const initiallyExpanded = !disableGate && !(hasCookie || fromEmail || disabled);
+  const initiallyExpanded = (setCookie === true) && !(hasCookie || fromEmail || disabled);
+
+  // Expire in 14 days (2yr if already signed up)
+  const days = fromEmail ? 365 * 2 : 14;
+  const maxAge = days * 24 * 60 * 60 * 1000;
 
   if (initiallyExpanded) {
-    // Expire in 14 days (2yr if already signed up)
-    const days = fromEmail ? 365 * 2 : 14;
-    const maxAge = days * 24 * 60 * 60 * 1000;
     res.cookie(cookieName, true, { maxAge });
   }
 
-  res.locals.newsletterState = { hasCookie, fromEmail, initiallyExpanded };
+  res.locals.newsletterState = {
+    hasCookie,
+    fromEmail,
+    disabled,
+    initiallyExpanded,
+    cookie: { name: cookieName, maxAge },
+  };
   next();
-});
+};

--- a/packages/global/middleware/with-content.js
+++ b/packages/global/middleware/with-content.js
@@ -9,6 +9,9 @@ module.exports = (params = {}) => withContent({
         id
         alias
       }
+      userRegistration {
+        isCurrentlyRequired
+      }
     }
   `,
 });

--- a/packages/global/routes/content.js
+++ b/packages/global/routes/content.js
@@ -2,6 +2,7 @@ const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/gra
 const companyQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-company');
 const contentQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-page');
 
+const newsletterState = require('../middleware/newsletter-state');
 const withContent = require('../middleware/with-content');
 const contact = require('../templates/content/contact');
 const company = require('../templates/content/company');
@@ -12,27 +13,27 @@ const content = require('../templates/content');
 
 module.exports = (app) => {
   const { site } = app.locals;
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment: companyQueryFragmentFn(site.get('leaders.alias')),
   }));
-  app.get('/*?media-gallery/:id(\\d{8})*', withContent({
+  app.get('/*?media-gallery/:id(\\d{8})*', newsletterState(), withContent({
     template: mediaGallery,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
   }));
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
   }));
-  app.get('/*?webinar/:id(\\d{8})*', withContent({
+  app.get('/*?webinar/:id(\\d{8})*', newsletterState(), withContent({
     template: webinar,
     queryFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?:id(\\d{8})*', newsletterState(), withContent({
     template: content,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
   }));

--- a/packages/global/routes/content.js
+++ b/packages/global/routes/content.js
@@ -1,3 +1,4 @@
+const { get } = require('@parameter1/base-cms-object-path');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const companyQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-company');
 const contentQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-page');
@@ -9,32 +10,55 @@ const company = require('../templates/content/company');
 const mediaGallery = require('../templates/content/media-gallery');
 const whitepaper = require('../templates/content/whitepaper');
 const webinar = require('../templates/content/webinar');
-const content = require('../templates/content');
+const contentTemplate = require('../templates/content');
+
+const formatResponse = ({ res, content }) => {
+  const {
+    initiallyExpanded,
+    hasCookie,
+    fromEmail,
+    disabled,
+    cookie,
+  } = res.locals.newsletterState;
+
+  if (get(content, 'userRegistration.isCurrentlyRequired') === true) {
+    res.locals.newsletterState.initiallyExpanded = false;
+  } else if (!initiallyExpanded && !hasCookie && !disabled && !fromEmail) {
+    res.cookie(cookie.name, true, { maxAge: cookie.maxAge });
+    res.locals.newsletterState.initiallyExpanded = true;
+  }
+};
 
 module.exports = (app) => {
   const { site } = app.locals;
-  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse,
   }));
-  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment: companyQueryFragmentFn(site.get('leaders.alias')),
+    formatResponse,
   }));
-  app.get('/*?media-gallery/:id(\\d{8})*', newsletterState(), withContent({
+  app.get('/*?media-gallery/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: mediaGallery,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
+    formatResponse,
   }));
-  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
+    formatResponse,
   }));
-  app.get('/*?webinar/:id(\\d{8})*', newsletterState(), withContent({
+  app.get('/*?webinar/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: webinar,
     queryFragment,
+    formatResponse,
   }));
-  app.get('/*?:id(\\d{8})*', newsletterState(), withContent({
-    template: content,
+  app.get('/*?:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
+    template: contentTemplate,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
+    formatResponse,
   }));
 };

--- a/packages/global/routes/content.js
+++ b/packages/global/routes/content.js
@@ -1,9 +1,8 @@
-const { get } = require('@parameter1/base-cms-object-path');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const companyQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-company');
 const contentQueryFragmentFn = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragment-factories/content-page');
 
-const newsletterState = require('../middleware/newsletter-state');
+const { newsletterState, formatContentResponse } = require('../middleware/newsletter-state');
 const withContent = require('../middleware/with-content');
 const contact = require('../templates/content/contact');
 const company = require('../templates/content/company');
@@ -12,53 +11,36 @@ const whitepaper = require('../templates/content/whitepaper');
 const webinar = require('../templates/content/webinar');
 const contentTemplate = require('../templates/content');
 
-const formatResponse = ({ res, content }) => {
-  const {
-    initiallyExpanded,
-    hasCookie,
-    fromEmail,
-    disabled,
-    cookie,
-  } = res.locals.newsletterState;
-
-  if (get(content, 'userRegistration.isCurrentlyRequired') === true) {
-    res.locals.newsletterState.initiallyExpanded = false;
-  } else if (!initiallyExpanded && !hasCookie && !disabled && !fromEmail) {
-    res.cookie(cookie.name, true, { maxAge: cookie.maxAge });
-    res.locals.newsletterState.initiallyExpanded = true;
-  }
-};
-
 module.exports = (app) => {
   const { site } = app.locals;
   app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
   app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment: companyQueryFragmentFn(site.get('leaders.alias')),
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
   app.get('/*?media-gallery/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: mediaGallery,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
   app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
   app.get('/*?webinar/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: webinar,
     queryFragment,
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
   app.get('/*?:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: contentTemplate,
     queryFragment: contentQueryFragmentFn(site.get('leaders.alias')),
-    formatResponse,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/packages/global/routes/scheduled-content.js
+++ b/packages/global/routes/scheduled-content.js
@@ -1,5 +1,5 @@
 const publishedContent = require('../templates/scheduled-content/default');
-const newsletterState = require('../middleware/newsletter-state');
+const { newsletterState } = require('../middleware/newsletter-state');
 
 module.exports = (app) => {
   app.get('/supplier-events', newsletterState(), (_, res) => {

--- a/packages/global/routes/scheduled-content.js
+++ b/packages/global/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const publishedContent = require('../templates/scheduled-content/default');
+const newsletterState = require('../middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/supplier-events', (_, res) => {
+  app.get('/supplier-events', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {
         alias: 'supplier-events',
@@ -12,7 +13,7 @@ module.exports = (app) => {
         endingAfter: (new Date()).valueOf(),
       });
   });
-  app.get('/webinars', (_, res) => {
+  app.get('/webinars', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {
         alias: 'webinars',
@@ -22,7 +23,7 @@ module.exports = (app) => {
         sortOrder: 'desc',
       });
   });
-  app.get('/white-papers', (_, res) => {
+  app.get('/white-papers', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {
         alias: 'white-papers',
@@ -30,7 +31,7 @@ module.exports = (app) => {
         title: 'Whitepapers',
       });
   });
-  app.get('/videos', (_, res) => {
+  app.get('/videos', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {
         alias: 'videos',
@@ -38,7 +39,7 @@ module.exports = (app) => {
         title: 'Videos',
       });
   });
-  app.get('/downloads', (_, res) => {
+  app.get('/downloads', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {
         alias: 'downloads',

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -11,7 +11,6 @@ const components = require('./components');
 const fragments = require('./fragments');
 const sharedRoutes = require('./routes');
 const paginated = require('./middleware/paginated');
-const newsletterState = require('./middleware/newsletter-state');
 const redirectHandler = require('./redirect-handler');
 const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
@@ -63,9 +62,6 @@ module.exports = (options = {}) => {
 
       // Use paginated middleware
       app.use(htmlSitemapPagination());
-
-      // Use newsletterState middleware
-      app.use(newsletterState());
 
       // Setup IdentityX + Omeda
       const omedaIdentityXConfig = getAsObject(options, 'siteConfig.omedaIdentityX');

--- a/sites/automationworld.com/server/routes/home.js
+++ b/sites/automationworld.com/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const home = require('../templates/index');
 

--- a/sites/automationworld.com/server/routes/home.js
+++ b/sites/automationworld.com/server/routes/home.js
@@ -1,9 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/automationworld.com/server/routes/website-section.js
+++ b/sites/automationworld.com/server/routes/website-section.js
@@ -1,22 +1,24 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 const podcasts = require('../templates/website-section/podcasts');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias(podcasts)', withWebsiteSection({
+  app.get('/:alias(podcasts)', newsletterState(), withWebsiteSection({
     template: podcasts,
     queryFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/automationworld.com/server/routes/website-section.js
+++ b/sites/automationworld.com/server/routes/website-section.js
@@ -1,7 +1,7 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');

--- a/sites/healthcarepackaging.com/server/routes/home.js
+++ b/sites/healthcarepackaging.com/server/routes/home.js
@@ -1,9 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/healthcarepackaging.com/server/routes/home.js
+++ b/sites/healthcarepackaging.com/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const home = require('../templates/index');
 

--- a/sites/healthcarepackaging.com/server/routes/scheduled-content.js
+++ b/sites/healthcarepackaging.com/server/routes/scheduled-content.js
@@ -1,5 +1,5 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
   app.get('/products', newsletterState(), (_, res) => {

--- a/sites/healthcarepackaging.com/server/routes/scheduled-content.js
+++ b/sites/healthcarepackaging.com/server/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/products', (_, res) => {
+  app.get('/products', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'products',
@@ -9,7 +10,7 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
-  app.get('/podcasts', (_, res) => {
+  app.get('/podcasts', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'podcasts',

--- a/sites/healthcarepackaging.com/server/routes/website-section.js
+++ b/sites/healthcarepackaging.com/server/routes/website-section.js
@@ -1,7 +1,7 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');

--- a/sites/healthcarepackaging.com/server/routes/website-section.js
+++ b/sites/healthcarepackaging.com/server/routes/website-section.js
@@ -1,16 +1,18 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/mundopmmi.com/server/routes/home.js
+++ b/sites/mundopmmi.com/server/routes/home.js
@@ -1,9 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/mundopmmi.com/server/routes/home.js
+++ b/sites/mundopmmi.com/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const home = require('../templates/index');
 

--- a/sites/mundopmmi.com/server/routes/scheduled-content.js
+++ b/sites/mundopmmi.com/server/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/eventos', (_, res) => {
+  app.get('/eventos', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'eventos',
@@ -12,7 +13,7 @@ module.exports = (app) => {
         endingAfter: (new Date()).valueOf(),
       });
   });
-  app.get('/podcasts', (_, res) => {
+  app.get('/podcasts', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'podcasts',

--- a/sites/mundopmmi.com/server/routes/scheduled-content.js
+++ b/sites/mundopmmi.com/server/routes/scheduled-content.js
@@ -1,5 +1,5 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
   app.get('/eventos', newsletterState(), (_, res) => {

--- a/sites/mundopmmi.com/server/routes/website-section.js
+++ b/sites/mundopmmi.com/server/routes/website-section.js
@@ -1,7 +1,7 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');

--- a/sites/mundopmmi.com/server/routes/website-section.js
+++ b/sites/mundopmmi.com/server/routes/website-section.js
@@ -1,16 +1,18 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/oemmagazine.org/server/routes/home.js
+++ b/sites/oemmagazine.org/server/routes/home.js
@@ -1,9 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/oemmagazine.org/server/routes/home.js
+++ b/sites/oemmagazine.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const home = require('../templates/index');
 

--- a/sites/oemmagazine.org/server/routes/scheduled-content.js
+++ b/sites/oemmagazine.org/server/routes/scheduled-content.js
@@ -1,5 +1,5 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
   app.get('/podcasts', newsletterState(), (_, res) => {

--- a/sites/oemmagazine.org/server/routes/scheduled-content.js
+++ b/sites/oemmagazine.org/server/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/podcasts', (_, res) => {
+  app.get('/podcasts', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'podcasts',

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -1,7 +1,7 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -1,16 +1,18 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/packworld.com/server/routes/home.js
+++ b/sites/packworld.com/server/routes/home.js
@@ -1,9 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/packworld.com/server/routes/home.js
+++ b/sites/packworld.com/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const home = require('../templates/index');
 

--- a/sites/packworld.com/server/routes/scheduled-content.js
+++ b/sites/packworld.com/server/routes/scheduled-content.js
@@ -1,5 +1,5 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
   app.get('/products', newsletterState(), (_, res) => {

--- a/sites/packworld.com/server/routes/scheduled-content.js
+++ b/sites/packworld.com/server/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/products', (_, res) => {
+  app.get('/products', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'products',
@@ -9,7 +10,7 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
-  app.get('/podcasts', (_, res) => {
+  app.get('/podcasts', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'podcasts',

--- a/sites/packworld.com/server/routes/website-section.js
+++ b/sites/packworld.com/server/routes/website-section.js
@@ -1,7 +1,7 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
-const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');

--- a/sites/packworld.com/server/routes/website-section.js
+++ b/sites/packworld.com/server/routes/website-section.js
@@ -1,16 +1,18 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const newsletterState = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/profoodworld.com/server/routes/home.js
+++ b/sites/profoodworld.com/server/routes/home.js
@@ -1,9 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/profoodworld.com/server/routes/scheduled-content.js
+++ b/sites/profoodworld.com/server/routes/scheduled-content.js
@@ -1,7 +1,8 @@
 const scheduledContent = require('@pmmi-media-group/package-global/templates/scheduled-content/default');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 module.exports = (app) => {
-  app.get('/products', (_, res) => {
+  app.get('/products', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'products',
@@ -9,7 +10,7 @@ module.exports = (app) => {
         title: 'Products',
       });
   });
-  app.get('/podcasts', (_, res) => {
+  app.get('/podcasts', newsletterState(), (_, res) => {
     res.marko(scheduledContent,
       {
         alias: 'podcasts',

--- a/sites/profoodworld.com/server/routes/website-section.js
+++ b/sites/profoodworld.com/server/routes/website-section.js
@@ -1,23 +1,24 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 const global250 = require('../templates/website-section/global-250');
 const global50 = require('../templates/website-section/global-50');
 
 module.exports = (app) => {
-  app.get('/:alias(global-250)', (_, res) => { res.marko(global250); });
-  app.get('/:alias(global-250/*)', (_, res) => { res.marko(global250); });
-  app.get('/:alias(global-50)', (_, res) => { res.marko(global50); });
-  app.get('/:alias(global-50/*)', (_, res) => { res.marko(global50); });
+  app.get('/:alias(global-250)', newsletterState(), (_, res) => { res.marko(global250); });
+  app.get('/:alias(global-250/*)', newsletterState(), (_, res) => { res.marko(global250); });
+  app.get('/:alias(global-50)', newsletterState(), (_, res) => { res.marko(global50); });
+  app.get('/:alias(global-50/*)', newsletterState(), (_, res) => { res.marko(global50); });
 
-  app.get('/:alias(leaders)', withWebsiteSection({
+  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
   }));
 
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));


### PR DESCRIPTION
Move the inclusion of the newsletterState out of the start server and down into the individual route that need to use it.  Also added configuration logic for excludeGatedContent & excludeContentTypes.

The way they have it configured at the moment it would not trigger on any content that is a page type or is gatedByReg.  It should still fire on all other content, section & home pages.  

Also update it so it only drops the cookie when initiallyExpanded is true.  Meaning it will only drop the cookie if it is telling it to display.  

Gated Piece of content(doesn't display or drop cookie) :
<img width="1462" alt="Screen Shot 2022-08-19 at 9 42 24 AM" src="https://user-images.githubusercontent.com/3845869/185644633-7b80e222-14f1-4e54-988e-989cee3b14a8.png">


Non restricted after that drops the cookie and displays pushdown:
<img width="1555" alt="Screen Shot 2022-08-19 at 9 46 26 AM" src="https://user-images.githubusercontent.com/3845869/185644972-adee9d5d-669f-4e13-b4e3-dc77d02bcf06.png">

