### PR TITLE
Use theme content attribution

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -41,12 +41,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       <marko-web-content-name tag="h1" block-name=blockName obj=content />
       <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
       <if(type !== "contact")>
-        <if(authors.length === 1)>
-          <theme-author-published-node author=authors[0] content=content lazyload=false />
-        </if>
-        <else-if(authors.length > 1)>
-          <default-theme-content-attribution obj=content elements=["authors"] />
-        </else-if>
+        <theme-content-attribution obj=content />
       </if>
       <if(displayPublishedDate && authors.length !== 1)>
         <default-theme-page-dates|{ blockName }|>


### PR DESCRIPTION
<img width="509" alt="Screen Shot 2022-08-29 at 1 14 53 PM" src="https://user-images.githubusercontent.com/2855198/187270139-360b76f2-af84-4486-a870-208306eadfb6.png">
