### PR TITLE
Remove max width for webinar content body

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -261,6 +261,11 @@ label {
       margin-bottom: 30px;
     }
   }
+  &--content-webinar {
+    .content-page-body {
+      max-width: none;
+    }
+  }
 }
 
 .site-header .search-sponsor__logo {


### PR DESCRIPTION
<img width="1199" alt="Screen Shot 2022-08-29 at 1 38 30 PM" src="https://user-images.githubusercontent.com/2855198/187274187-9560c494-f732-42a3-b9be-7d0eaeaa9b68.png">
