### PR TITLE
Outline translations function for use in new ```marko-web-i18n``` package

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -3,6 +3,7 @@ import MonoRailLeaders from '@pmmi-media-group/package-theme-monorail-leaders/br
 
 const ImageSlider = () => import(/* webpackChunkName: "global-image-slider" */ './image-slider.vue');
 const DynamicSiteMenuPositioner = () => import(/* webpackChunkName: "dynamic-site-menu-positioner" */ './dynamic-site-menu-positioner.vue');
+const Translated = () => import(/* webpackChunkName: "translated" */ './translated.vue');
 
 export default (Browser) => {
   MonoRail(Browser);
@@ -10,4 +11,5 @@ export default (Browser) => {
 
   Browser.register('DynamicSiteMenuPositioner', DynamicSiteMenuPositioner);
   Browser.register('GlobalImageSlider', ImageSlider);
+  Browser.register('Translated', Translated);
 };

--- a/packages/global/browser/translated.vue
+++ b/packages/global/browser/translated.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    {{ translate('firstNameLabel') }}
+  </div>
+</template>
+
+<script>
+import i18n from '../utils/i18n-vue';
+
+export default {
+  props: {
+    lang: {
+      type: String,
+      default: 'en',
+    },
+  },
+  methods: {
+    translate(key) {
+      return i18n(this.lang, key);
+    },
+  },
+};
+</script>

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -34,5 +34,8 @@
     },
     "<below-container>": {},
     "<foot>": {}
+  },
+  "<global-translated>": {
+    "template": "./translated.marko"
   }
 }

--- a/packages/global/components/translated.marko
+++ b/packages/global/components/translated.marko
@@ -1,0 +1,9 @@
+$ const { site } = out.global;
+
+$ const i18n = require('../utils/i18n-marko');
+
+$ const lang = site.config.lang || "en";
+
+<marko-web-browser-component name="Translated" props={ lang: lang } />
+
+<div>${i18n(lang, "surnameLabel")}</div>

--- a/packages/global/utils/i18n-marko.js
+++ b/packages/global/utils/i18n-marko.js
@@ -1,0 +1,11 @@
+const translations = require('./translations');
+
+module.exports = (lang, fieldLabelKey) => {
+  if (!translations[lang]) {
+    throw new Error(`No translations available for requested language ${lang}!`);
+  }
+  if (!translations[lang][fieldLabelKey]) {
+    throw new Error(`No translations available in ${lang} for requested key ${fieldLabelKey}!`);
+  }
+  return translations[lang][fieldLabelKey];
+};

--- a/packages/global/utils/i18n-vue.js
+++ b/packages/global/utils/i18n-vue.js
@@ -1,0 +1,11 @@
+import translations from './translations';
+
+export default (lang, fieldLabelKey) => {
+  if (!translations[lang]) {
+    throw new Error(`No translations available for requested language ${lang}!`);
+  }
+  if (!translations[lang][fieldLabelKey]) {
+    throw new Error(`No translations available in ${lang} for requested key ${fieldLabelKey}!`);
+  }
+  return translations[lang][fieldLabelKey];
+};

--- a/packages/global/utils/translations.js
+++ b/packages/global/utils/translations.js
@@ -1,0 +1,28 @@
+module.exports = {
+  en: {
+    firstNameLabel: 'First Name',
+    surnameLabel: 'Last Name',
+    emailLabel: 'Email Address',
+    phoneLabel: 'Phone Number',
+    companyLabel: 'Company Name',
+    jobTitleLabel: 'Job Title',
+    countryLabel: 'Country',
+    countryPlaceholder: 'Select country...',
+    zipLabel: 'ZIP/Postal Code',
+    commentsLabel: 'Comment',
+    submitLabel: 'Submit',
+  },
+  es: {
+    firstNameLabel: 'Primer nombre',
+    surnameLabel: 'Apellidos',
+    emailLabel: 'Correo electrónico',
+    phoneLabel: 'Número telefónico',
+    companyLabel: 'Nombre de compañía',
+    jobTitleLabel: 'Título de trabajo',
+    countryLabel: 'País',
+    countryPlaceholder: 'Selecciona un país...',
+    zipLabel: 'Código postal',
+    commentsLabel: 'Comentarios',
+    submitLabel: 'Enviar',
+  },
+};

--- a/sites/mundopmmi.com/server/templates/index.marko
+++ b/sites/mundopmmi.com/server/templates/index.marko
@@ -18,6 +18,7 @@ $ const buttonLabels = { continue: continueLabel };
     <div class="row">
       <div class="col-lg-8">
         <global-leaders-home-page />
+        <global-translated />
       </div>
       <div class="col-lg-4">
         <global-native-x-list-block />


### PR DESCRIPTION
![Test-Translation-Function](https://user-images.githubusercontent.com/46794001/187492510-2e3a4b6e-ca6a-4792-8b79-bb7452de647c.png)


This outlines the use of what will hopefully become a standalone ```marko-web-i18n``` package that will allow for unified translations across the various ```marko-web``` packages.