### PR TITLE
Fix inquiry form to pass content vs content.company on non company pages

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -217,7 +217,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       <div class="col-lg-4">
         <if(type === 'product' && content.company)>
           <div class="mb-block">
-            <theme-company-inquiry-form-block content=content.company initially-expanded=false consent-checkboxes=getAsArray(site, 'config.inquiry.consentCheckboxes') />
+            <theme-company-inquiry-form-block content=content initially-expanded=false consent-checkboxes=getAsArray(site, 'config.inquiry.consentCheckboxes') />
           </div>
         </if>
         <global-leaders-contextual content-id=id />


### PR DESCRIPTION
Update the inquiry form on non company content pages to pass in the content object vs the content.company object to ensure the linking in the reporting and emails is correct.

**New:** 
<img width="358" alt="Screen Shot 2022-09-14 at 10 39 17 AM" src="https://user-images.githubusercontent.com/3845869/190200121-4b7fbac8-9203-4a3f-a1e9-ed9b14ddb07d.png">
**Old:**
<img width="375" alt="Screen Shot 2022-09-14 at 10 39 33 AM" src="https://user-images.githubusercontent.com/3845869/190200175-40a5f827-091c-4c42-9ab4-b8d4b7be70bc.png">

