### PR TITLE
Reduce Native-x image size

### DIFF
--- a/packages/global/components/blocks/native-x-list.marko
+++ b/packages/global/components/blocks/native-x-list.marko
@@ -21,7 +21,7 @@ $ const uri = nxConfig.getUri();
               image-position="right"
               with-section=false
               with-dates=false
-              image={ lazyload: true, width: 180, height: 120, ar: "3:2" }
+              image={ lazyload: true, width: 100, height: 67, ar: "3:2" }
               ...convertAdToNode(ads[0], { sectionName })
             />
           </div>
@@ -38,7 +38,7 @@ $ const uri = nxConfig.getUri();
               image-position="right"
               with-section=true
               with-dates=false
-              image={ lazyload: true, width: 180, height: 120, ar: "3:2" }
+              image={ lazyload: true, width: 100, height: 67, ar: "3:2" }
               ...convertAdToNode(ads[0], { sectionName })
             />
           </div>


### PR DESCRIPTION
Current (broken):
<img width="1304" alt="Screen Shot 2022-09-20 at 8 21 18 AM" src="https://user-images.githubusercontent.com/64623209/191269080-1093e6cc-9aee-4323-9d8f-3f2f88baa2c8.png">

Fix:
<img width="1219" alt="Screen Shot 2022-09-20 at 8 21 08 AM" src="https://user-images.githubusercontent.com/64623209/191269070-7ca0a2c4-b032-4171-adb2-f164409dd55e.png">