### PR TITLE
Pass correct attributes, scheduled content pages

### DIFF
--- a/packages/global/components/layouts/scheduled-content/index.marko
+++ b/packages/global/components/layouts/scheduled-content/index.marko
@@ -19,7 +19,7 @@ $ const perPage = 18;
 $ const type = "scheduled-content";
 $ const description = defaultDescription(title, config);
 
-<theme-default-page name=title>
+<theme-default-page title=title description=description>
   <@head>
     <theme-section-feed-block|{ totalCount }| with-section=false query-name=queryName count-only=true>
       <@query-params include-content-types=includeContentTypes />

--- a/sites/automationworld.com/server/templates/website-section/podcasts.marko
+++ b/sites/automationworld.com/server/templates/website-section/podcasts.marko
@@ -23,7 +23,7 @@ $ const queryParams = {
 
 <marko-web-query|{ nodes }| name=queryName params=queryParams>
   $ const excludeContentIds = nodes.map((node) => node.id);
-  <theme-default-page name=title>
+  <theme-default-page title=title description=description>
     <@head>
       <theme-section-feed-block|{ totalCount }| with-section=false query-name=queryName count-only=true>
         <@query-params include-content-types=includeContentTypes exclude-content-ids=excludeContentIds />


### PR DESCRIPTION
Example of scheduled-content layout (Packworld Downloads page https://packworld.com/downloads):
![Correct-published-content-titles](https://user-images.githubusercontent.com/46794001/194077022-5e9a3197-7a0a-41d9-a2be-245e0780965c.png)
![Downloads-Head](https://user-images.githubusercontent.com/46794001/194077024-861a8f0f-3448-47dc-8908-f8fe67afc67f.png)

AW Podcasts page (https://automationworld.com/podcasts):
![Podcasts-AW](https://user-images.githubusercontent.com/46794001/194077026-125495ba-087c-43b2-b7d3-6daeb739b64f.png)
![Podcasts-Head](https://user-images.githubusercontent.com/46794001/194077044-925e11ce-0f63-4032-acbd-5b39b5bcf920.png)
