### PR TITLE
Do not auto-expand contextual leaders block, when no context available

### DIFF
--- a/packages/global/components/leaders/contextual.marko
+++ b/packages/global/components/leaders/contextual.marko
@@ -5,7 +5,6 @@ $ const { contentId } = input;
   <marko-web-leaders props={
     contentId,
     open: "auto",
-    expanded: true,
     iconSet: "chevron",
     sectionAlias: site.get("leaders.alias"),
     headerImgSrc: site.get("leaders.header.imgSrc"),


### PR DESCRIPTION
No context:
![Non-Contextual](https://user-images.githubusercontent.com/46794001/194344404-431716ea-aec4-499a-83eb-138a92f8a861.png)

With context:
![Contextual](https://user-images.githubusercontent.com/46794001/194344410-165335d4-4bed-47e5-a091-7a6887150743.png)
