### PR TITLE
If embedded video is gated, replace with primary image

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -65,24 +65,6 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       <div class="col-lg-8">
         <div class="content-page-body">
           <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
-            <if(content.embedCode)>
-              $ const iframeContent = contentIframe(content);
-              <marko-web-content-embed-code block-name=blockName obj=iframeContent />
-            </if>
-            <else-if(type === "media-gallery")>
-              <!-- <marko-web-image-slider images=images /> -->
-            </else-if>
-            <else-if(displayPrimaryImage)>
-              $ let forceDisplay;
-              $ if (type === "contact") forceDisplay = "left";
-              $ if (type === "video") forceDisplay = "none";
-              <theme-primary-image-block
-                obj=content.primaryImage
-                force-display=forceDisplay
-                fluid-width=700
-              />
-            </else-if>
-
             $ const requiresRegistration = (get(content, "userRegistration.isCurrentlyRequired") || contentGatingHandler({ content, req }));
             $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
             <marko-web-identity-x-access|context|
@@ -91,6 +73,11 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
             >
               <if(!context.canAccess || context.requiresUserInput)>
                 $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });
+                $ const primaryImage = getContentPreview({primaryImage: content.primaryImage, selector: "primaryImage" });
+                <theme-primary-image-block
+                  obj=content.primaryImage
+                  fluid-width=700
+                />
                 <marko-web-content-body block-name=blockName obj={ body } />
 
                 <div class="content-page-preview-overlay" />
@@ -104,6 +91,23 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                 />
               </if>
               <else>
+                <if(content.embedCode)>
+                  $ const iframeContent = contentIframe(content);
+                  <marko-web-content-embed-code block-name=blockName obj=iframeContent />
+                </if>
+                <else-if(type === "media-gallery")>
+                  <!-- <marko-web-image-slider images=images /> -->
+                </else-if>
+                <else-if(displayPrimaryImage)>
+                  $ let forceDisplay;
+                  $ if (type === "contact") forceDisplay = "left";
+                  $ if (type === "video") forceDisplay = "none";
+                  <theme-primary-image-block
+                    obj=content.primaryImage
+                    force-display=forceDisplay
+                    fluid-width=700
+                  />
+                </else-if>
 
                 $ const bodyId = `content-body-${content.id}`;
 


### PR DESCRIPTION
Not gated & not logged in:
<img width="436" alt="Screen Shot 2022-10-10 at 8 00 13 AM" src="https://user-images.githubusercontent.com/64623209/194872348-bcdd26c9-e495-43ac-b209-d7a72f4feee7.png">
<img width="569" alt="Screen Shot 2022-10-10 at 8 00 16 AM" src="https://user-images.githubusercontent.com/64623209/194872358-ae488ea4-d1e9-435f-9f84-724fcdacb067.png">
Gated:
<img width="667" alt="Screen Shot 2022-10-10 at 7 59 50 AM" src="https://user-images.githubusercontent.com/64623209/194872450-4c93af07-c07c-4c98-80e8-aacda2c7b496.png">
Gated & logged in:
<img width="412" alt="Screen Shot 2022-10-10 at 7 59 21 AM" src="https://user-images.githubusercontent.com/64623209/194872488-a9ed7937-97ca-4540-b54b-a886e429c9f6.png">
<img width="570" alt="Screen Shot 2022-10-10 at 7 59 25 AM" src="https://user-images.githubusercontent.com/64623209/194872491-8cf60a05-46ce-40bf-ab86-923ca0b6c4d3.png">
