### PR TITLE
Add route level redirect handling for legacy digital edition urls

### DIFF
--- a/packages/global/routes/digital-edition-redirects.js
+++ b/packages/global/routes/digital-edition-redirects.js
@@ -1,0 +1,12 @@
+const { cleanPath } = require('@parameter1/base-cms-utils');
+
+module.exports = (app) => {
+  // Prgamatic redirect for legacy digitial edition urls
+  // old: "http://www.automationworld.com/sites/default/files/digital_edition/december2014/AW_December_2014_Optimized/index.html",
+  // new: "https://digitaleditions.automationworld.com/december2014/AW_December_2014_Optimized/index.html",
+  app.get('/sites/default/files/digital_edition/:alias([a-zA-Z0-9-_/]+)/index.html', (req, res) => {
+    const digitalOrigin = req.app.locals.config.website('origin').replace('https://www.', 'https://digitaleditions.');
+    const { alias } = req.params;
+    res.redirect(301, `${digitalOrigin}/${cleanPath(alias)}/index.html`);
+  });
+};

--- a/packages/global/routes/digital-edition-redirects.js
+++ b/packages/global/routes/digital-edition-redirects.js
@@ -1,7 +1,7 @@
 const { cleanPath } = require('@parameter1/base-cms-utils');
 
 module.exports = (app) => {
-  // Prgamatic redirect for legacy digitial edition urls
+  // Programatic redirect for legacy digitial edition urls
   // old: "http://www.automationworld.com/sites/default/files/digital_edition/december2014/AW_December_2014_Optimized/index.html",
   // new: "https://digitaleditions.automationworld.com/december2014/AW_December_2014_Optimized/index.html",
   app.get('/sites/default/files/digital_edition/:alias([a-zA-Z0-9-_/]+)/index.html', (req, res) => {

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -67,7 +67,7 @@ module.exports = (app, siteConfig) => {
 
   content(app);
 
-  // Prgamatic redirect for legacy digitial edition urls
+  // Programatic redirect for legacy digitial edition urls
   // old: "http://www.automationworld.com/sites/default/files/digital_edition/december2014/AW_December_2014_Optimized/index.html",
   // new: "https://digitaleditions.automationworld.com/december2014/AW_December_2014_Optimized/index.html",
   digitalEditionRedirects(app);

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -7,6 +7,7 @@ const magazine = require('@parameter1/base-cms-marko-web-theme-monorail-magazine
 
 const leaders = require('./leaders');
 const feed = require('./feed');
+const digitalEditionRedirects = require('./digital-edition-redirects');
 const content = require('./content');
 const scheduledContent = require('./scheduled-content');
 const dynamicPage = require('./dynamic-page');
@@ -65,4 +66,9 @@ module.exports = (app, siteConfig) => {
   dynamicPage(app);
 
   content(app);
+
+  // Prgamatic redirect for legacy digitial edition urls
+  // old: "http://www.automationworld.com/sites/default/files/digital_edition/december2014/AW_December_2014_Optimized/index.html",
+  // new: "https://digitaleditions.automationworld.com/december2014/AW_December_2014_Optimized/index.html",
+  digitalEditionRedirects(app);
 };


### PR DESCRIPTION
Add new digitalEditionRedirect route support to redirect 

Legacy: `http://www.}automationworld.com/sites/default/files/digital_edition/december2014/AW_December_2014_Optimized/index.html`

Corrected URL: 
`https://digitaleditions.automationworld.com/december2014/AW_December_2014_Optimized/index.html`

Replacing www.automationworls.com with digitaleditions.automationworld.com & removing the `/sites/default/file/digital_edition` portion of the url.  