### PR TITLE
Alter category names to be valid values in GAM for key value targetting

### DIFF
--- a/packages/global/utils/gam-content-categories.js
+++ b/packages/global/utils/gam-content-categories.js
@@ -1,8 +1,18 @@
 const { getAsArray } = require('@parameter1/base-cms-object-path');
 
+// For more information on why this is being done please consult: https://support.google.com/admanager/answer/10020177?hl=en
+// Replace chars that aren't forward slash, space, letter, number, underscore or dash with nothing
+// Replace double space with single underscore (prevents a case of Foo & Bar becoming Foo__Bar)
+// Replace spaces and forward slashes with underscores
+const gamifyCategoryName = name => name
+  .replace(/[^/" "a-zA-Z0-9_-]/g, '')
+  .replace(/[" "]{2}/g, '_')
+  .replace(/[" "/]/g, '_');
+
 const categories = (obj, key, value) => ([...new Set([
   ...getAsArray(obj, key),
-  ...(value ? [value.name] : []),
+
+  ...(value ? [gamifyCategoryName(value.name)] : []),
 ])]);
 
 module.exports = content => getAsArray(content, 'taxonomy.edges')


### PR DESCRIPTION
Reference: https://support.google.com/admanager/answer/10020177?hl=en additional firsthand account via this screenshot:

<img width="209" alt="Screen Shot 2022-10-18 at 12 58 26 PM" src="https://user-images.githubusercontent.com/46794001/196509797-4f51c596-7fb8-4875-89ff-c2f7f8544f73.png">

AW: 
![Automation-World](https://user-images.githubusercontent.com/46794001/196509901-8de6a52a-e4ef-4b75-a40a-c92768f4fffe.png)

PW:
![PW](https://user-images.githubusercontent.com/46794001/196509954-6ba873a0-763a-44b4-a0cf-f443bd058ccb.png)
