### PR TITLE
Remove advertisement label overrides

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -213,17 +213,6 @@ label {
       display: block;
     }
   }
-  &--with-label {
-    > *:first-child {
-      &::before {
-        padding-bottom: 1rem;
-        font-size: 12px;
-        color: $gray-500;
-        text-transform: none;
-        content: "Advertisement";
-      }
-    }
-  }
 }
 
 // End right rail content layout CSS


### PR DESCRIPTION
<img width="847" alt="Screen Shot 2022-10-31 at 2 17 19 PM" src="https://user-images.githubusercontent.com/2855198/199091505-1deb720e-f31f-4e50-819e-c17fd8582dac.png">
<img width="1168" alt="Screen Shot 2022-10-31 at 2 17 15 PM" src="https://user-images.githubusercontent.com/2855198/199091510-53c11878-0e6d-4cba-bc4c-c22179fc9879.png">
