### PR TITLE
Pull in i18n to Login page, translate appropriately

### DIFF
--- a/packages/global/templates/user/login.marko
+++ b/packages/global/templates/user/login.marko
@@ -1,4 +1,4 @@
-$ const { config } = out.global;
+$ const { config, i18n } = out.global;
 
 $ const type = "login";
 $ const title = "Log in";

--- a/sites/mundopmmi.com/config/i18n.js
+++ b/sites/mundopmmi.com/config/i18n.js
@@ -77,5 +77,5 @@ module.exports = {
   type: 'Tipo',
   account: 'Cuenta',
   'sign in': 'Suscríbase',
-  'log in to mundo PMMI': 'Conéctese a Mundo PMMI',
+  'log in to mundo pmmi': 'Conéctese a Mundo PMMI',
 };


### PR DESCRIPTION
Ref https://github.com/parameter1/pmmi-media-group-websites/pull/466 somehow this page translation ended up going onto the wrong PR and was incomplete. This should now correct it

<img width="1920" alt="Screen Shot 2022-11-08 at 8 24 17 AM" src="https://user-images.githubusercontent.com/46794001/200590148-341b8178-e2a6-4e6e-94f9-1e67adda9b8d.png">
