### PR TITLE
Add webinars feed layout with upcoming/archive logic

### DIFF
--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -29,6 +29,16 @@
     "@name": "string",
     "@page-node": "object"
   },
+  "<global-website-section-webinars-feed-layout>": {
+    "template": "./webinars-feed.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@id": "number",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object"
+  },
   "<global-website-section-home-layout>": {
     "template": "./home.marko",
     "<head>": {},

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -1,0 +1,234 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { id, alias, name, pageNode } = input;
+$ const sections = getAsArray(input, "sections");
+
+$ const { site, pagination: p, i18n } = out.global;
+$ const continueLabel = i18n("Sign Me Up!");
+$ const loginEmailLabel = i18n("Work Email");
+$ const buttonLabels = { continue: continueLabel };
+$ const perPage = 12;
+$ const now = Date.now();
+
+$ const queryParams = {
+  requiresImage: false,
+  sectionBubbling: false,
+  includeContentTypes: ["Webinar"],
+
+};
+$ const upcomingQueryParams = {
+  ...queryParams,
+  beginningAfter: now,
+  linit: 25,
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
+};
+$ const archiveQueryParams = {
+  ...queryParams,
+  beginningBefore: now,
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
+};
+
+<!-- Correct queryParams format to send to pagination controls -->
+$ const countQueryParams = {
+  ...queryParams,
+  beginning: {
+    before: now,
+  },
+};
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@head>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params ...countQueryParams />
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </theme-section-feed-block>
+  </@head>
+
+  <@section|{ aliases }| modifiers=["break-container", "first"]>
+    <theme-gam-define-display-ad
+      name="leaderboard"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section|{ blockName, section, aliases }|>
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+    <marko-web-website-section-description obj=section />
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+  </@section>
+
+  <@section|{ aliases }| modifiers=["upcoming"] >
+    <if(p.page === 1)>
+      <theme-section-feed-block alias=alias>
+        <@header>
+          Upcoming
+        </@header>
+        <@query-params ...upcomingQueryParams />
+        <@after>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@after>
+      </theme-section-feed-block>
+    </if>
+  </@section>
+
+  <@section modifiers=["archives"]>
+    <theme-section-feed-block alias=alias lazyload=false>
+      <@header>
+        On Demand
+      </@header>
+      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage }) />
+    </theme-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <theme-section-feed-block alias=alias>
+      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 3 }) />
+    </theme-section-feed-block>
+  </@section>
+
+  <@section>
+    <marko-web-identity-x-context|{ hasUser }|>
+      <if(!hasUser)>
+        <identity-x-newsletter-form-inline
+          button-labels=buttonLabels
+          login-email-label=loginEmailLabel
+          login-email-placeholder="example@yourcompany.com"
+          type="inlineSection"
+        />
+      </if>
+    </marko-web-identity-x-context>
+  </@section>
+
+  <@section>
+    <theme-section-feed-block alias=alias>
+      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 6 }) />
+    </theme-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <theme-section-feed-block alias=alias>
+      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 9 }) />
+    </theme-section-feed-block>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params ...countQueryParams />
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+      />
+    </theme-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <theme-top-stories-block query-params={ optionName: "Pinned" } />
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-native-x-promo-card-block placement-name="marketing" aliases=aliases />
+  </@section>
+
+  <@section>
+    $ const defaultParams = {
+        queryParams: { includeContentTypes: ["Product"] },
+        section: { name: "Products", canonicalPath: "/products" },
+    };
+    $ const productsParams = defaultValue(site.get("productsParams"), defaultParams);
+    <theme-content-card-list-block ...productsParams />
+  </@section>
+
+  <@section>
+    <theme-client-side-most-popular-block />
+  </@section>
+
+  $ const publicationIds = site.get("magazine.publicationIds");
+  <if(publicationIds.length)>
+    <@section>
+      <theme-magazine-issues-block publication-id=publicationIds[0] />
+    </@section>
+  </if>
+
+  <@section>
+    <theme-content-card-deck-block
+      query-params={ includeContentTypes: ["Document"], limit: 4 }
+      section={ name: `${i18n("Downloads")}`, canonicalPath: "/downloads" }
+    />
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+</global-website-section-default-layout>

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -78,7 +78,8 @@ $ const countQueryParams = {
         section=section
       />
     </if>
-
+  </@section>
+  <@section|{ blockName, section, aliases }| modifiers=["webinars"]>
     <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
       <if(p.page > 1)>${value}: Page ${p.page}</if>
       <else>${value}</else>
@@ -92,11 +93,8 @@ $ const countQueryParams = {
         section=section
       />
     </if>
-  </@section>
-
-  <@section|{ aliases }| modifiers=["upcoming"] >
     <if(p.page === 1)>
-      <theme-section-feed-block alias=alias>
+      <theme-section-feed-block alias=alias modifiers=["upcoming"]>
         <@header>
           Upcoming
         </@header>
@@ -111,63 +109,11 @@ $ const countQueryParams = {
         </@after>
       </theme-section-feed-block>
     </if>
-  </@section>
-
-  <@section modifiers=["archives"]>
-    <theme-section-feed-block alias=alias lazyload=false>
+    <theme-section-feed-block alias=alias lazyload=false modifiers=["archives"]>
       <@header>
         On Demand
       </@header>
-      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage }) />
-    </theme-section-feed-block>
-  </@section>
-
-  <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-
-  <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 3 }) />
-    </theme-section-feed-block>
-  </@section>
-
-  <@section>
-    <marko-web-identity-x-context|{ hasUser }|>
-      <if(!hasUser)>
-        <identity-x-newsletter-form-inline
-          button-labels=buttonLabels
-          login-email-label=loginEmailLabel
-          login-email-placeholder="example@yourcompany.com"
-          type="inlineSection"
-        />
-      </if>
-    </marko-web-identity-x-context>
-  </@section>
-
-  <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 6 }) />
-    </theme-section-feed-block>
-  </@section>
-
-  <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-
-  <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params ...archiveQueryParams limit=3 skip=p.skip({ perPage, skip: 9 }) />
+      <@query-params ...archiveQueryParams limit=12 />
     </theme-section-feed-block>
     <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
       <@query-params ...countQueryParams />
@@ -177,15 +123,6 @@ $ const countQueryParams = {
         path=alias
       />
     </theme-section-feed-block>
-  </@section>
-
-  <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
   </@section>
 
   <@section>

--- a/packages/global/routes/scheduled-content.js
+++ b/packages/global/routes/scheduled-content.js
@@ -13,16 +13,6 @@ module.exports = (app) => {
         endingAfter: (new Date()).valueOf(),
       });
   });
-  app.get('/webinars', newsletterState(), (_, res) => {
-    res.marko(publishedContent,
-      {
-        alias: 'webinars',
-        includeContentTypes: ['Webinar'],
-        title: 'Webinars',
-        sortField: 'startDate',
-        sortOrder: 'desc',
-      });
-  });
   app.get('/white-papers', newsletterState(), (_, res) => {
     res.marko(publishedContent,
       {

--- a/packages/global/scss/components/_webinars-feed.scss
+++ b/packages/global/scss/components/_webinars-feed.scss
@@ -1,0 +1,9 @@
+.page-wrapper__section {
+  $self: &;
+  // Hide the On Demand title when upcoming block is not present.
+  + #{ $self }--upcoming:empty + #{ $self }--archives {
+    .node-list__header {
+      display: none;
+     }
+  }
+}

--- a/packages/global/scss/components/_webinars-feed.scss
+++ b/packages/global/scss/components/_webinars-feed.scss
@@ -1,9 +1,23 @@
-.page-wrapper__section {
-  $self: &;
-  // Hide the On Demand title when upcoming block is not present.
-  + #{ $self }--upcoming:empty + #{ $self }--archives {
-    .node-list__header {
-      display: none;
-     }
+.page-wrapper {
+  &__section {
+    &--webinars {
+      .node-list__header {
+        @include skin-typography($style: "section-header-small", $link-style: "primary");
+      }
+      .node-list--upcoming {
+        // border-bottom: solid 1px $gray-200;
+        // padding-bottom: map-get($spacers, 2);
+      }
+      .node-list--archives {
+        .node-list__header {
+          display: none;
+        }
+      }
+      .node-list--upcoming ~ .node-list--archives {
+        .node-list__header {
+          display: initial;
+        }
+      }
+    }
   }
 }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -15,6 +15,7 @@
 @import "./components/leaders";
 @import "./components/native-x-list";
 @import "./components/native-x-announcement";
+@import "./components/webinars-feed";
 
 // @import "../components/magazine/scss/index";
 

--- a/packages/global/templates/website-section/webinars.marko
+++ b/packages/global/templates/website-section/webinars.marko
@@ -1,0 +1,8 @@
+$ const { id, alias, name, pageNode } = input;
+
+<global-website-section-webinars-feed-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+/>

--- a/sites/automationworld.com/server/routes/website-section.js
+++ b/sites/automationworld.com/server/routes/website-section.js
@@ -2,12 +2,18 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 const podcasts = require('../templates/website-section/podcasts');
 
 module.exports = (app) => {
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/healthcarepackaging.com/server/routes/website-section.js
+++ b/sites/healthcarepackaging.com/server/routes/website-section.js
@@ -2,11 +2,17 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/mundopmmi.com/server/routes/website-section.js
+++ b/sites/mundopmmi.com/server/routes/website-section.js
@@ -2,11 +2,17 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -2,11 +2,17 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -2,17 +2,11 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
-const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
-  app.get('/:alias(webinars)', withWebsiteSection({
-    template: webinars,
-    queryFragment,
-  }));
-
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/packworld.com/server/routes/website-section.js
+++ b/sites/packworld.com/server/routes/website-section.js
@@ -1,12 +1,18 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/profoodworld.com/server/routes/website-section.js
+++ b/sites/profoodworld.com/server/routes/website-section.js
@@ -2,6 +2,7 @@ const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middlewar
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@pmmi-media-group/package-theme-monorail-leaders/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const section = require('../templates/website-section');
 const leaders = require('../templates/website-section/leaders');
 const global250 = require('../templates/website-section/global-250');
@@ -12,6 +13,11 @@ module.exports = (app) => {
   app.get('/:alias(global-250/*)', newsletterState(), (_, res) => { res.marko(global250); });
   app.get('/:alias(global-50)', newsletterState(), (_, res) => { res.marko(global50); });
   app.get('/:alias(global-50/*)', newsletterState(), (_, res) => { res.marko(global50); });
+
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
 
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,


### PR DESCRIPTION
Add new webinars route, template & layout to utilize the begining After/Before query logic.  This will pull(limit: 25) webinars beginining in the future to the top of page one and display them above the On Demand list that would normally display on this page.

Thing to note with this is that if there becomes a larger volumn of upcoming webinars we will have to revisit this page and figure out how to make it more of a destination/landing page vs the paginated version it is now.

### With Up Coming Webinars:

![webinars-with-upcoming](https://user-images.githubusercontent.com/3845869/204913035-a0c205f1-49c5-4f6f-ab15-ea15fcf55745.jpg)


### Without Up Coming Webinars:
![webinars-no-upcoming](https://user-images.githubusercontent.com/3845869/204913047-2de46312-878c-4ac1-8897-7e0cc4d62c8b.jpg)

