### PR TITLE
Remove section restriction and switch sort order

### DIFF
--- a/packages/global/components/layouts/website-section/events-feed.marko
+++ b/packages/global/components/layouts/website-section/events-feed.marko
@@ -20,7 +20,7 @@ $ const queryParams = {
   endingAfter: now,
   sort: {
     field: "startDate",
-    order: "desc",
+    order: "asc",
   },
 
 };
@@ -29,7 +29,6 @@ $ const pmgQueryParams = {
   requiresImage: true,
   includeLabels: ["PMG"],
   limit: 25,
-  sectionAlias: alias,
   queryFragment,
 };
 $ const standardQueryParams = {


### PR DESCRIPTION
Switch the sore order to ascending and remove the section restrition on the pmg event query.

![Screen Shot 2023-03-10 at 12 08 59 PM](https://user-images.githubusercontent.com/3845869/224391660-ccb1c774-2afd-4d9d-aff9-e21947c6e1e7.png)
