### PR TITLE
Hide pmg-event wrapper when empty

### DIFF
--- a/packages/global/scss/components/pmg-events.scss
+++ b/packages/global/scss/components/pmg-events.scss
@@ -16,3 +16,11 @@
     }
   }
 }
+
+.pmg-events {
+  &__wrapper {
+    &:empty {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
###Updated:
<img width="1024" alt="Screen Shot 2023-03-21 at 12 22 46 PM" src="https://user-images.githubusercontent.com/3845869/226691498-8d5dd3d6-a34f-44ac-8565-f33d9b83ce58.png">

###Old:
<img width="1027" alt="Screen Shot 2023-03-21 at 12 23 57 PM" src="https://user-images.githubusercontent.com/3845869/226691594-52a27d5e-9d9a-4bbf-85c4-c73c7496395c.png">
