### PR TITLE
Adjust z-index of site-header to allow native ad to be clicked

### DIFF
--- a/sites/cpgnext.com/server/styles/index.scss
+++ b/sites/cpgnext.com/server/styles/index.scss
@@ -52,6 +52,7 @@ $theme-site-navbar-secondary-font-size: 16px !default;
 .site-header {
   padding-top: 40px;
   position: fixed;
+  z-index: 10;
 }
 .document-container {
   top: calculate-navbar-height-for(default, $additional-padding: 40px);


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2023-08-03 at 1 28 57 PM" src="https://github.com/parameter1/pmmi-media-group-websites/assets/64623209/3e06ba11-c435-42f9-8706-0b2fa04d5ac3">
