### PR TITLE
Super Category (Taxonomy) pages

### DIFF
--- a/packages/global/components/leaders/marko.json
+++ b/packages/global/components/leaders/marko.json
@@ -8,5 +8,9 @@
   "<global-leaders-contextual>": {
     "template": "./contextual.marko",
     "@content-id": "number"
+  },
+  "<global-leaders-taxonomy-page>": {
+    "template": "./taxonomy-page.marko",
+    "@section-ids": "array,"
   }
 }

--- a/packages/global/components/leaders/taxonomy-page.marko
+++ b/packages/global/components/leaders/taxonomy-page.marko
@@ -1,0 +1,22 @@
+$ const { site, req } = out.global;
+$ const { sectionIds } = input;
+
+<if(sectionIds && site.get("leaders.enabled"))>
+  <marko-web-leaders props={
+    sectionIds: sectionIds,
+    open: "auto",
+    iconSet: "chevron",
+    sectionAlias: site.get("leaders.alias"),
+    headerImgSrc: site.get("leaders.header.imgSrc"),
+    headerImgSrcset: site.get("leaders.header.imgSrcset"),
+    headerImgAlt: site.get("leaders.title"),
+    displayCallout: false,
+    offsetTop: 50,
+    viewAllHref: '/leaders',
+    columns: 1,
+    calloutPrefix: site.get("leaders.calloutPrefix") || "Browse these",
+    calloutValue: site.get("leaders.calloutValue") || "leading suppliers",
+    viewAllText: site.get("leaders.viewAllText") || "View All Companies &gt;",
+    contextual: true
+  }/>
+</if>

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -18,8 +18,12 @@ const printContent = require('./print-content');
 const publicFiles = require('./public-files');
 const redirects = require('./redirects');
 const staticPage = require('./static-page');
+const taxonomyCategory = require('./taxonomy-category');
 
 module.exports = (app, siteConfig) => {
+  // Taxonomy category pages
+  taxonomyCategory(app);
+
   leaders(app);
   // Feed
   feed(app);

--- a/packages/global/routes/taxonomy-category.js
+++ b/packages/global/routes/taxonomy-category.js
@@ -1,0 +1,57 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const gql = require('graphql-tag');
+const createError = require('http-errors');
+const template = require('../templates/taxonomy-category');
+const getEdgeNodes = require('../utils/get-edge-nodes');
+
+const query = gql`
+  query WithTaxonomy($input: TaxonomyQueryInput!) {
+    taxonomy(input: $input) {
+      id
+      name
+      type
+      urlPath
+    }
+  }
+`;
+
+const relatedLeadersSectionsQuery = gql`
+  query LeadersSectionsFromTaxonomy($siteId: ObjectID, $taxonomyIds: [Int!]!) {
+    websiteSections(input: {
+      siteId: $siteId,
+      taxonomyIds: $taxonomyIds,
+      pagination: { limit: 0 },
+      sort: { field: name, order: asc },
+    }) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+module.exports = (app) => {
+  app.get('/taxonomy-category/:id(\\d+)', asyncRoute(async (req, res) => {
+    const { apollo } = res.locals;
+    const id = parseInt(req.params.id, 10);
+    const input = { id };
+    const variables = { input };
+    const { data } = await apollo.query({ query, variables });
+    const { taxonomy } = data;
+    if (!taxonomy || taxonomy.type !== 'Category') {
+      throw createError(404, `No taxonomy category was found for ID '${id}'`);
+    }
+
+    const siteId = req.app.locals.config.website('id');
+    const { data: sectionData } = await apollo.query({
+      query: relatedLeadersSectionsQuery,
+      variables: { siteId, taxonomyIds: [id] },
+    });
+    const sections = getEdgeNodes(sectionData, 'websiteSections');
+    const leadersSectionIds = sections.map((section) => section.id);
+
+    return res.marko(template, { ...taxonomy, leadersSectionIds });
+  }));
+};

--- a/packages/global/templates/taxonomy-category/index.marko
+++ b/packages/global/templates/taxonomy-category/index.marko
@@ -38,7 +38,6 @@ $ const queryParams = {
           <div class="col-lg-8">
             <marko-web-query|{ nodes }| name="all-published-content" params=queryParams>
               <marko-web-node-list
-                inner-justified=true
                 flush-x=true
                 flush-y=false
                 modifiers=["section-feed"]
@@ -50,7 +49,6 @@ $ const queryParams = {
                 </@nodes>
               </marko-web-node-list>
             </marko-web-query>
-
             <theme-query-total-count|{ totalCount }| name="all-published-content" params={ includeTaxonomyIds: [id] }>
               <theme-pagination-controls
                 per-page=perPage
@@ -71,6 +69,16 @@ $ const queryParams = {
                   with-image=false
                 />
               </if>
+              <else>
+                <div class="newsletter-form">
+                  <div class="newsletter-signup-banner newsletter-signup-banner--large"><!---->
+                    <div class="newsletter-signup-banner__right-col newsletter-signup-banner__right-col--large">
+                      <div class="newsletter-signup-banner__name newsletter-signup-banner__name--large">Thanks for confirming!</div>
+                      <div class="newsletter-signup-banner__description newsletter-signup-banner__description--large">Save us on your safelist.</div>
+                    </div>
+                  </div>
+                </div>
+              </else>
             </marko-web-identity-x-context>
             <if(site.get("leaders.enabled"))>
               <global-leaders-taxonomy-page section-ids=leadersSectionIds />
@@ -81,7 +89,6 @@ $ const queryParams = {
             />
           </div>
         </div>
-
       </@section>
 
       <@section>

--- a/packages/global/templates/taxonomy-category/index.marko
+++ b/packages/global/templates/taxonomy-category/index.marko
@@ -1,0 +1,96 @@
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
+
+$ const { id, name, type, description, leadersSectionIds } = input;
+$ const { site, GAM, req, i18n, pagination: p } = out.global;
+$ const perPage = 12;
+$ const continueLabel = i18n("Sign Me Up!");
+$ const loginEmailLabel = i18n("Work Email");
+$ const actionText = i18n("signing up to receive your email notifications");
+$ const buttonLabels = { continue: continueLabel };
+
+$ const queryParams = {
+  limit: perPage,
+  skip: p.skip({ perPage }),
+  includeTaxonomyIds: [id],
+  queryFragment,
+};
+
+<marko-web-default-page-layout type="taxonomy" title=`${type}: ${name}` description=description>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section modifiers=["first"]>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="section_page"
+          modifiers=["inter-block"]
+        />
+      </@section>
+
+      <@section|{ blockName }|>
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name }>
+          <if(p.page > 1)>${value}: ${i18n("Page")} ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+
+        <div class="row">
+          <div class="col-lg-8">
+            <marko-web-query|{ nodes }| name="all-published-content" params=queryParams>
+              <marko-web-node-list
+                inner-justified=true
+                flush-x=true
+                flush-y=false
+                modifiers=["section-feed"]
+              >
+                <@nodes nodes=nodes>
+                  <@slot|{ node }|>
+                    <theme-section-feed-content-node node=node />
+                  </@slot>
+                </@nodes>
+              </marko-web-node-list>
+            </marko-web-query>
+
+            <theme-query-total-count|{ totalCount }| name="all-published-content" params={ includeTaxonomyIds: [id] }>
+              <theme-pagination-controls
+                per-page=perPage
+                total-count=totalCount
+                path=req.path
+              />
+            </theme-query-total-count>
+          </div>
+          <div class="col-lg-4">
+            <marko-web-identity-x-context|{ hasUser }|>
+              <if(!hasUser)>
+                <identity-x-newsletter-form-inline
+                  button-labels=buttonLabels
+                  login-email-label=loginEmailLabel
+                  login-email-placeholder="example@yourcompany.com"
+                  type="inlineSection"
+                  action-text=actionText
+                  with-image=false
+                />
+              </if>
+            </marko-web-identity-x-context>
+            <if(site.get("leaders.enabled"))>
+              <global-leaders-taxonomy-page section-ids=leadersSectionIds />
+            </if>
+            <theme-gam-define-display-ad
+              name="inline-content"
+              position="section_page"
+            />
+          </div>
+        </div>
+
+      </@section>
+
+      <@section>
+        <theme-gam-define-display-ad
+          name="rotation"
+          position="section_page"
+          modifiers=["inter-block"]
+        />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/global/templates/taxonomy-category/index.marko
+++ b/packages/global/templates/taxonomy-category/index.marko
@@ -29,13 +29,53 @@ $ const queryParams = {
       </@section>
 
       <@section|{ blockName }|>
-        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name }>
-          <if(p.page > 1)>${value}: ${i18n("Page")} ${p.page}</if>
-          <else>${value}</else>
-        </marko-web-website-section-name>
-
         <div class="row">
           <div class="col-lg-8">
+            $ const pinnedParams = {
+              limit: 1,
+              skip: 0,
+              includeTaxonomyIds: [id],
+              includeLabels: ['Taxonomy Introduction'],
+              queryFragment,
+            }
+            <marko-web-query|{ nodes }| name="all-published-content" params=pinnedParams>
+              $ const pinnedNode = nodes.slice(0, 1)[0] || {};
+              $ const { id, type, siteContext, primaryImage } = pinnedNode;
+              $ const pinnedImageNode = {
+                id,
+                type,
+                siteContext,
+                primaryImage
+              };
+              <marko-web-element block-name="top-stories" name="row">
+                <marko-web-element block-name="top-stories" name="col" modifiers=["hero"]>
+                  <theme-content-node
+                    image-position="top"
+                    card=true
+                    flush=true
+                    image-only=true
+                    modifiers=["top-stories-hero-image"]
+                    node=pinnedImageNode
+                  >
+                    <@image fluid=true width=600 ar="3:2" lazyload=false />
+                  </theme-content-node>
+                </marko-web-element>
+                <marko-web-element block-name="top-stories" name="col" modifiers=["list"]>
+                  <theme-content-node
+                    full-height=true
+                    card=true
+                    display-image=false
+                    flush=true
+                    modifiers=["top-stories-hero"]
+                    node=pinnedNode
+                  />
+                </marko-web-element>
+              </marko-web-element>
+            </marko-web-query>
+            <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name }>
+              <if(p.page > 1)>${value}: ${i18n("Page")} ${p.page}</if>
+              <else>${value}</else>
+            </marko-web-website-section-name>
             <marko-web-query|{ nodes }| name="all-published-content" params=queryParams>
               <marko-web-node-list
                 flush-x=true

--- a/packages/global/utils/get-as-array.js
+++ b/packages/global/utils/get-as-array.js
@@ -1,6 +1,0 @@
-const { get } = require('object-path');
-
-module.exports = (obj, path) => {
-  const v = get(obj, path, []);
-  return Array.isArray(v) ? v : [];
-};

--- a/packages/global/utils/get-as-array.js
+++ b/packages/global/utils/get-as-array.js
@@ -1,0 +1,6 @@
+const { get } = require('object-path');
+
+module.exports = (obj, path) => {
+  const v = get(obj, path, []);
+  return Array.isArray(v) ? v : [];
+};

--- a/packages/global/utils/get-edge-nodes.js
+++ b/packages/global/utils/get-edge-nodes.js
@@ -1,0 +1,3 @@
+const getAsArray = require('./get-as-array');
+
+module.exports = (obj, path) => getAsArray(obj, `${path}.edges`).map((edge) => edge.node);

--- a/packages/global/utils/get-edge-nodes.js
+++ b/packages/global/utils/get-edge-nodes.js
@@ -1,3 +1,3 @@
-const getAsArray = require('./get-as-array');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
 
 module.exports = (obj, path) => getAsArray(obj, `${path}.edges`).map((edge) => edge.node);

--- a/packages/theme-monorail-leaders/browser/leaders-block.vue
+++ b/packages/theme-monorail-leaders/browser/leaders-block.vue
@@ -267,7 +267,7 @@ export default {
     async loadSections() {
       const { sectionIds } = this;
       if (sectionIds && sectionIds.length) {
-        const url = `/__sections-from-ids?sectionIds=${this.sectionids}`;
+        const url = `/__sections-from-ids?sectionIds=${sectionIds}`;
         const res = await fetch(url);
         const json = await res.json();
         const sections = getEdgeNodes(json, 'websiteSections')


### PR DESCRIPTION
Without a "Pinned" article:
![Screenshot from 2023-10-10 12-55-45](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/3fc919ed-9791-4d14-98c8-904c21d5a9dd)
![Screenshot from 2023-10-11 09-39-45](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/b568d7e7-e30b-4373-a4a5-824521928d51)

With "Pinned" article:
![Screenshot from 2023-10-11 10-07-23](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/966f6731-1b3f-48f0-bee0-410cc2b80bee)


Will presently use the routing `/taxonomy-category/TAXONOMY_CATEGORY_ID`


