### PR TITLE
Addition of Machinery Basics block for PW and PFW content pages

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -2,7 +2,13 @@ import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import contentIframe from "@pmmi-media-group/package-global/utils/content-iframe";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
-$ const { site, contentGatingHandler, req, i18n } = out.global;
+$ const {
+  site,
+  config,
+  contentGatingHandler,
+  req,
+  i18n
+} = out.global;
 $ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 
@@ -290,6 +296,15 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
         position="content_page"
         aliases=aliases
         modifiers=["inter-block"]
+      />
+    </@section>
+  </if>
+
+  <if(["5d88cedef175132c008b456b", "5d88cf1af175132c008b4577"].includes(get(config, "websiteContext.id")))>
+    <@section>
+      <theme-content-card-deck-block
+        query-params={ includeLabels: ["Machinery Basics"], limit: 4 }
+        section={ name: "Machinery Basics", canonicalPath: "/machinery-basics" }
       />
     </@section>
   </if>

--- a/packages/global/components/layouts/scheduled-content/index.marko
+++ b/packages/global/components/layouts/scheduled-content/index.marko
@@ -9,6 +9,7 @@ $ const { config, GAM, pagination: p, i18n } = out.global;
 $ const {
   alias,
   title,
+  includeLabels,
   includeContentTypes,
   sortField,
   sortOrder,
@@ -22,7 +23,7 @@ $ const description = defaultDescription(title, config);
 <theme-default-page title=title description=description>
   <@head>
     <theme-section-feed-block|{ totalCount }| with-section=false query-name=queryName count-only=true>
-      <@query-params include-content-types=includeContentTypes />
+      <@query-params include-labels=includeLabels include-content-types=includeContentTypes />
       <theme-pagination-controls
         per-page=perPage
         total-count=totalCount
@@ -62,6 +63,7 @@ $ const description = defaultDescription(title, config);
             limit=18
             skip=p.skip({ perPage })
             query-fragment=queryFragment
+            include-labels=includeLabels
             include-content-types=includeContentTypes
             sort-field=sortField
             sort-order=sortOrder
@@ -69,7 +71,7 @@ $ const description = defaultDescription(title, config);
           />
         </theme-section-feed-block>
         <theme-section-feed-block|{ totalCount }| query-name=queryName count-only=true>
-          <@query-params include-content-types=includeContentTypes />
+          <@query-params include-labels=includeLabels include-content-types=includeContentTypes />
           <theme-pagination-controls
             per-page=perPage
             total-count=totalCount

--- a/sites/packworld.com/server/routes/scheduled-content.js
+++ b/sites/packworld.com/server/routes/scheduled-content.js
@@ -22,4 +22,14 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/machinery-basics', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'machinery-basics',
+        includeLabels: ['Machinery Basics'],
+        title: 'Machinery Basics',
+      },
+    );
+  });
 };

--- a/sites/profoodworld.com/server/routes/scheduled-content.js
+++ b/sites/profoodworld.com/server/routes/scheduled-content.js
@@ -22,4 +22,14 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/machinery-basics', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'machinery-basics',
+        includeLabels: ['Machinery Basics'],
+        title: 'Machinery Basics',
+      },
+    );
+  });
 };


### PR DESCRIPTION
Showing location on site for various sites (HCP shouldn't have the block):
![Screenshot from 2023-12-01 11-54-45](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/da09f6f4-011d-4816-9dce-b839e9d68f43)
![Screenshot from 2023-12-01 11-54-49](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/f995579b-535d-49e8-b825-e7e51bcd5909)
![Screenshot from 2023-12-01 11-56-19](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/4c485eb4-8fa0-4c43-b52b-2c3010fe5685)

What the Machinery Basics page looks like
![image](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/961d15dd-57d7-404d-9d18-8bf4042c11e1)
