### PR TITLE
Supplier News, Podcasts, Webinars, Events Section and Content Page Logic Adjustments

### DIFF
--- a/packages/global/components/blocks/published-content-list.marko
+++ b/packages/global/components/blocks/published-content-list.marko
@@ -30,6 +30,15 @@ $ const blockName = "section-list";
         </@header>
         <@nodes nodes=nodes>
           <@slot|{ node, index }|>
+            $ if (["event", "podcast", "webinar"].includes(node.type)) {
+              const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
+              node.primarySection = {
+                name: typeName,
+                fullName: typeName,
+                alias: `${node.type}s`,
+                canonicalPath: `/${node.type}s`,
+              }
+            }
             <if(index === 0)>
               <theme-content-node
                 image-position="top"

--- a/packages/global/components/blocks/published-content-list.marko
+++ b/packages/global/components/blocks/published-content-list.marko
@@ -1,5 +1,6 @@
 import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import sectionFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-info";
+import handleContentTypePrimarySection from "../../utils/handle-content-type-primary-section";
 
 $ const { sectionId, excludeContentIds } = input;
 
@@ -31,13 +32,7 @@ $ const blockName = "section-list";
         <@nodes nodes=nodes>
           <@slot|{ node, index }|>
             $ if (["event", "podcast", "webinar"].includes(node.type)) {
-              const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
-              node.primarySection = {
-                name: `${typeName}s`,
-                fullName: `${typeName}s`,
-                alias: `${node.type}s`,
-                canonicalPath: `/${node.type}s`,
-              }
+              node.primarySection = handleContentTypePrimarySection({ i18n, node });
             }
             <if(index === 0)>
               <theme-content-node

--- a/packages/global/components/blocks/published-content-list.marko
+++ b/packages/global/components/blocks/published-content-list.marko
@@ -33,8 +33,8 @@ $ const blockName = "section-list";
             $ if (["event", "podcast", "webinar"].includes(node.type)) {
               const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
               node.primarySection = {
-                name: typeName,
-                fullName: typeName,
+                name: `${typeName}s`,
+                fullName: `${typeName}s`,
                 alias: `${node.type}s`,
                 canonicalPath: `/${node.type}s`,
               }

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -1,6 +1,7 @@
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import contentIframe from "@pmmi-media-group/package-global/utils/content-iframe";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
+import handleContentTypePrimarySection from "@pmmi-media-group/package-global/utils/handle-content-type-primary-section";
 
 $ const {
   site,
@@ -68,7 +69,17 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
           const replacedHierarchy = [sectionHierarchy.pop()]
           primarySection.hierarchy = replacedHierarchy;
         };
-        <theme-content-page-breadcrumbs section=primarySection />
+        <if(["event", "podcast", "webinar"].includes(content.type))>
+          $ const handledPrimarySection = handleContentTypePrimarySection({ i18n, node: content });
+          $ const handledPrimarySectionWithHierarchy = {
+            ...handledPrimarySection,
+            hierarchy: [handledPrimarySection],
+          };
+          <theme-content-page-breadcrumbs section=handledPrimarySectionWithHierarchy />
+        </if>
+        <else>
+          <theme-content-page-breadcrumbs section=primarySection />
+        </else>
       </else>
       <marko-web-content-name tag="h1" block-name=blockName obj=content />
       <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />

--- a/packages/global/components/layouts/content/webinar.marko
+++ b/packages/global/components/layouts/content/webinar.marko
@@ -1,5 +1,6 @@
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import contentIframe from "@pmmi-media-group/package-global/utils/content-iframe";
+import handleContentTypePrimarySection from "@pmmi-media-group/package-global/utils/handle-content-type-primary-section";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
 $ const { site, contentGatingHandler, req, i18n } = out.global;
@@ -39,7 +40,12 @@ $ const actionText = i18n("signing up to receive your email notifications");
       primarySection.hierarchy = replacedHierarchy;
     };
     <div class="content-page-header">
-      <theme-content-page-breadcrumbs section=primarySection />
+      $ const handledPrimarySection = handleContentTypePrimarySection({ i18n, node: content });
+      $ const handledPrimarySectionWithHierarchy = {
+        ...handledPrimarySection,
+        hierarchy: [handledPrimarySection],
+      };
+      <theme-content-page-breadcrumbs section=handledPrimarySectionWithHierarchy />
       <marko-web-content-name tag="h1" block-name=blockName obj=content />
       <theme-page-dates|{ blockName }|>
         Starts: <marko-web-content-start-date block-name=blockName obj=content format="MMMM Do YYYY, h:mm a z"/>

--- a/packages/global/components/layouts/scheduled-content/index.marko
+++ b/packages/global/components/layouts/scheduled-content/index.marko
@@ -16,13 +16,14 @@ $ const {
   endingAfter,
 } = input;
 $ const perPage = 18;
+$ const withSection = defaultValue(input.withSection, false);
 
 $ const type = "scheduled-content";
 $ const description = defaultDescription(title, config);
 
 <theme-default-page title=title description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| with-section=false query-name=queryName count-only=true>
+    <theme-section-feed-block|{ totalCount }| with-section=withSection query-name=queryName count-only=true>
       <@query-params include-labels=includeLabels include-content-types=includeContentTypes />
       <theme-pagination-controls
         per-page=perPage
@@ -58,7 +59,7 @@ $ const description = defaultDescription(title, config);
         </div>
       </@section>
       <@section|{ blockName }|>
-        <theme-section-feed-block with-section=false query-name=queryName lazyload=false>
+        <theme-section-feed-block with-section=withSection query-name=queryName lazyload=false>
           <@query-params
             limit=18
             skip=p.skip({ perPage })

--- a/packages/global/components/layouts/website-section/events-feed.marko
+++ b/packages/global/components/layouts/website-section/events-feed.marko
@@ -3,7 +3,7 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 import queryFragment from "../../../graphql/fragments/pmg-events";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { alias, description, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
 $ const {
@@ -23,18 +23,15 @@ $ const queryParams = {
   sectionBubbling: false,
   includeContentTypes: ["Event"],
   endingAfter: now,
-  sort: {
-    field: "startDate",
-    order: "asc",
-  },
-
+  sortField: "startDate",
+  sortOrder: "asc",
+  queryFragment,
 };
 $ const pmgQueryParams = {
   ...queryParams,
   requiresImage: true,
   includeLabels: ["PMG"],
   limit: 25,
-  queryFragment,
 };
 $ const standardQueryParams = {
   ...queryParams,
@@ -44,20 +41,23 @@ $ const standardQueryParams = {
 
 <!-- Correct queryParams format to send to pagination controls -->
 $ const countQueryParams = {
-  ...queryParams,
+  requiresImage: false,
+  sectionBubbling: false,
+  includeContentTypes: ["Event"],
+  endingAfter: now,
+  queryFragment,
   beginning: {
     before: now,
   },
+  sort: {
+    field: "startDate",
+    order: "asc",
+  }
 };
 
-<global-website-section-default-layout
-  id=id
-  alias=alias
-  name=name
-  page-node=pageNode
->
+<theme-default-page title=name description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
       <@query-params ...countQueryParams />
       <theme-pagination-controls
         per-page=perPage
@@ -67,107 +67,116 @@ $ const countQueryParams = {
       />
     </theme-section-feed-block>
   </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section|{ aliases }| modifiers=["break-container", "first"]>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+      <if(input.beforeName)>
+        <@section|{ blockName, section, aliases }|>
+          <${input.beforeName}
+            aliases=aliases
+            block-name=blockName
+            section=section
+          />
+        </@section>
+      </if>
 
-  <@section|{ aliases }| modifiers=["break-container", "first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-  <if(input.beforeName)>
-    <@section|{ blockName, section, aliases }|>
-      <${input.beforeName}
-        aliases=aliases
-        block-name=blockName
-        section=section
-      />
-    </@section>
-  </if>
+      <@section|{ blockName, section, aliases }| modifiers=["events"]>
+        <if(p.page === 1)>
+          <marko-web-element block-name="pmg-events" name="wrapper">
+            <marko-web-query|{ nodes }| name="all-published-content" params=pmgQueryParams>
+              <marko-web-element class="page-wrapper__website-section-name" block-name="pmg-events" name="header">
+                ${config.siteName()} ${i18n("Events")}
+              </marko-web-element>
+              $ const finalNodes = nodes.map((node) => ({
+                ...node,
+                primarySection: { canonicalPath: `/${alias}`, name }
+              }));
+              <theme-section-feed-flow nodes=finalNodes lazyload=false />
+            </marko-web-query>
+          </marko-web-element>
+        </if>
 
-  <@section|{ blockName, section, aliases }| modifiers=["events"]>
-    <if(p.page === 1)>
-      <marko-web-element block-name="pmg-events" name="wrapper">
-        <theme-section-feed-block alias=alias lazyload=false>
-          <@before>
-            <marko-web-element class="page-wrapper__website-section-name" block-name="pmg-events" name="header">
-              ${config.siteName()} ${i18n("Events")}
-            </marko-web-element>
-          </@before>
-          <@query-params ...pmgQueryParams />
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name }>
+          <if(p.page > 1)>${value}: Page ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+        <marko-web-website-section-description obj={ description } />
+
+        <if(input.afterName)>
+          <${input.afterName}
+            aliases=aliases
+            block-name=blockName
+            section=section
+          />
+        </if>
+
+        <marko-web-query|{ nodes }| name="all-published-content" params=standardQueryParams>
+          $ const finalNodes = nodes.map((node) => ({
+            ...node,
+            primarySection: { canonicalPath: `/${alias}`, name }
+          }));
+          <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false />
+        </marko-web-query>
+        <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+          <@query-params ...countQueryParams />
+          <theme-pagination-controls
+            per-page=perPage
+            total-count=totalCount
+            path=alias
+          />
         </theme-section-feed-block>
-      </marko-web-element>
-    </if>
+      </@section>
 
-    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
-      <if(p.page > 1)>${value}: Page ${p.page}</if>
-      <else>${value}</else>
-    </marko-web-website-section-name>
-    <marko-web-website-section-description obj=section />
+      <@section>
+        <theme-top-stories-block query-params={ optionName: "Pinned" } />
+      </@section>
 
-    <if(input.afterName)>
-      <${input.afterName}
-        aliases=aliases
-        block-name=blockName
-        section=section
-      />
-    </if>
+      <@section|{ aliases }|>
+        <theme-native-x-promo-card-block placement-name="marketing" aliases=aliases />
+      </@section>
 
-    <theme-section-feed-block alias=alias lazyload=false modifiers=["archives"]>
-      <@query-params ...standardQueryParams />
-    </theme-section-feed-block>
-    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
-      <@query-params ...countQueryParams />
-      <theme-pagination-controls
-        per-page=perPage
-        total-count=totalCount
-        path=alias
-      />
-    </theme-section-feed-block>
-  </@section>
+      <@section>
+        $ const defaultParams = {
+            queryParams: { includeContentTypes: ["Product"] },
+            section: { name: "Products", canonicalPath: "/products" },
+        };
+        $ const productsParams = defaultValue(site.get("productsParams"), defaultParams);
+        <theme-content-card-list-block ...productsParams />
+      </@section>
 
-  <@section>
-    <theme-top-stories-block query-params={ optionName: "Pinned" } />
-  </@section>
+      <@section>
+        <global-client-side-most-popular-block />
+      </@section>
 
-  <@section|{ aliases }|>
-    <theme-native-x-promo-card-block placement-name="marketing" aliases=aliases />
-  </@section>
+      $ const publicationIds = site.getAsArray("magazine.publicationIds");
+      <if(publicationIds.length)>
+        <@section>
+          <theme-magazine-issues-block publication-id=publicationIds[0] />
+        </@section>
+      </if>
 
-  <@section>
-    $ const defaultParams = {
-        queryParams: { includeContentTypes: ["Product"] },
-        section: { name: "Products", canonicalPath: "/products" },
-    };
-    $ const productsParams = defaultValue(site.get("productsParams"), defaultParams);
-    <theme-content-card-list-block ...productsParams />
-  </@section>
+      <@section>
+        <theme-content-card-deck-block
+          query-params={ includeContentTypes: ["Document"], limit: 4 }
+          section={ name: `${i18n("Downloads")}`, canonicalPath: "/downloads" }
+        />
+      </@section>
 
-  <@section>
-    <global-client-side-most-popular-block />
-  </@section>
-
-  $ const publicationIds = site.getAsArray("magazine.publicationIds");
-  <if(publicationIds.length)>
-    <@section>
-      <theme-magazine-issues-block publication-id=publicationIds[0] />
-    </@section>
-  </if>
-
-  <@section>
-    <theme-content-card-deck-block
-      query-params={ includeContentTypes: ["Document"], limit: 4 }
-      section={ name: `${i18n("Downloads")}`, canonicalPath: "/downloads" }
-    />
-  </@section>
-
-  <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-</global-website-section-default-layout>
+      <@section|{ aliases }|>
+        <theme-gam-define-display-ad
+          name="rotation"
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</theme-default-page>

--- a/packages/global/components/layouts/website-section/events-feed.marko
+++ b/packages/global/components/layouts/website-section/events-feed.marko
@@ -98,7 +98,7 @@ $ const countQueryParams = {
               </marko-web-element>
               $ const finalNodes = nodes.map((node) => ({
                 ...node,
-                primarySection: { canonicalPath: `/${alias}`, name }
+                primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
               }));
               <theme-section-feed-flow nodes=finalNodes lazyload=false />
             </marko-web-query>
@@ -122,7 +122,7 @@ $ const countQueryParams = {
         <marko-web-query|{ nodes }| name="website-scheduled-content" params=standardQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
-            primarySection: { canonicalPath: `/${alias}`, name }
+            primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
           }));
           <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false />
         </marko-web-query>

--- a/packages/global/components/layouts/website-section/events-feed.marko
+++ b/packages/global/components/layouts/website-section/events-feed.marko
@@ -23,8 +23,10 @@ $ const queryParams = {
   sectionBubbling: false,
   includeContentTypes: ["Event"],
   endingAfter: now,
-  sortField: "startDate",
-  sortOrder: "asc",
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
   queryFragment,
 };
 $ const pmgQueryParams = {
@@ -57,7 +59,7 @@ $ const countQueryParams = {
 
 <theme-default-page title=name description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
       <@query-params ...countQueryParams />
       <theme-pagination-controls
         per-page=perPage
@@ -90,7 +92,7 @@ $ const countQueryParams = {
       <@section|{ blockName, section, aliases }| modifiers=["events"]>
         <if(p.page === 1)>
           <marko-web-element block-name="pmg-events" name="wrapper">
-            <marko-web-query|{ nodes }| name="all-published-content" params=pmgQueryParams>
+            <marko-web-query|{ nodes }| name="website-scheduled-content" params=pmgQueryParams>
               <marko-web-element class="page-wrapper__website-section-name" block-name="pmg-events" name="header">
                 ${config.siteName()} ${i18n("Events")}
               </marko-web-element>
@@ -117,14 +119,14 @@ $ const countQueryParams = {
           />
         </if>
 
-        <marko-web-query|{ nodes }| name="all-published-content" params=standardQueryParams>
+        <marko-web-query|{ nodes }| name="website-scheduled-content" params=standardQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
             primarySection: { canonicalPath: `/${alias}`, name }
           }));
           <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false />
         </marko-web-query>
-        <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+        <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
           <@query-params ...countQueryParams />
           <theme-pagination-controls
             per-page=perPage

--- a/packages/global/components/layouts/website-section/events-feed.marko
+++ b/packages/global/components/layouts/website-section/events-feed.marko
@@ -1,5 +1,6 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
+import handleContentTypePrimarySection from "../../../utils/handle-content-type-primary-section";
 
 import queryFragment from "../../../graphql/fragments/pmg-events";
 
@@ -98,7 +99,7 @@ $ const countQueryParams = {
               </marko-web-element>
               $ const finalNodes = nodes.map((node) => ({
                 ...node,
-                primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
+                primarySection: handleContentTypePrimarySection({ i18n, node })
               }));
               <theme-section-feed-flow nodes=finalNodes lazyload=false />
             </marko-web-query>
@@ -122,7 +123,7 @@ $ const countQueryParams = {
         <marko-web-query|{ nodes }| name="website-scheduled-content" params=standardQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
-            primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
           }));
           <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false />
         </marko-web-query>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -1,6 +1,7 @@
 import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
+import handleContentTypePrimarySection from "../../../utils/handle-content-type-primary-section";
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
@@ -75,11 +76,8 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
-        }),
+            primarySection: handleContentTypePrimarySection({ i18n, node })
+          }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
     </marko-web-query>
@@ -100,10 +98,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
@@ -130,10 +125,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
@@ -155,10 +147,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -1,3 +1,4 @@
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
@@ -10,6 +11,11 @@ $ const loginEmailLabel = i18n("Work Email");
 $ const buttonLabels = { continue: continueLabel };
 $ const perPage = 12;
 $ const actionText = i18n("signing up to receive your email notifications");
+$ const queryParams = {
+  sectionAlias: alias,
+  limit: 3,
+  queryFragment
+};
 
 <global-website-section-default-layout
   id=id
@@ -64,9 +70,19 @@ $ const actionText = i18n("signing up to receive your email notifications");
       />
     </if>
 
-    <theme-section-feed-block alias=alias lazyload=false>
-      <@query-params limit=3 skip=p.skip({ perPage }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
   </@section>
 
   <@section|{ aliases }|>
@@ -79,9 +95,19 @@ $ const actionText = i18n("signing up to receive your email notifications");
   </@section>
 
   <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 3 }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: 3 });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
   </@section>
 
   <@section>
@@ -99,9 +125,19 @@ $ const actionText = i18n("signing up to receive your email notifications");
   </@section>
 
   <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 6 }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: 6 });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
   </@section>
 
   <@section|{ aliases }|>
@@ -114,9 +150,19 @@ $ const actionText = i18n("signing up to receive your email notifications");
   </@section>
 
   <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 9 }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: 9 });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
     <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
       <theme-pagination-controls
         per-page=perPage

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -34,20 +34,18 @@
     "@sections <section>[]": {},
     "<before-name>": {},
     "<after-name>": {},
-    "@id": "number",
     "@alias": "string",
-    "@name": "string",
-    "@page-node": "object"
+    "@description": "string",
+    "@name": "string"
   },
   "<global-website-section-webinars-feed-layout>": {
     "template": "./webinars-feed.marko",
     "@sections <section>[]": {},
     "<before-name>": {},
     "<after-name>": {},
-    "@id": "number",
     "@alias": "string",
-    "@name": "string",
-    "@page-node": "object"
+    "@description": "string",
+    "@name": "string"
   },
   "<global-website-section-home-layout>": {
     "template": "./home.marko",

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -22,14 +22,18 @@ $ const upcomingQueryParams = {
   ...queryParams,
   beginningAfter: now,
   limit: 25,
-  sortField: "startDate",
-  sortOrder: "asc",
+  sort: {
+    field: "startDate",
+    order: "asc",
+  }
 };
 $ const archiveQueryParams = {
   ...queryParams,
   beginningBefore: now,
-  sortField: "startDate",
-  sortOrder: "desc",
+  sort: {
+    field: "startDate",
+    order: "desc",
+  },
   limit: perPage,
   skip: p.skip({ perPage })
 };
@@ -44,7 +48,7 @@ $ const countQueryParams = {
 
 <theme-default-page title=name description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
       <@query-params ...countQueryParams />
       <theme-pagination-controls
         per-page=perPage
@@ -89,7 +93,7 @@ $ const countQueryParams = {
           />
         </if>
         <if(p.page === 1)>
-          <marko-web-query|{ nodes }| name="all-published-content" params=upcomingQueryParams>
+          <marko-web-query|{ nodes }| name="website-scheduled-content" params=upcomingQueryParams>
             $ const finalNodes = nodes.map((node) => ({
               ...node,
               primarySection: { canonicalPath: `/${alias}`, name }
@@ -105,7 +109,7 @@ $ const countQueryParams = {
             />
           </marko-web-query>
         </if>
-        <marko-web-query|{ nodes }| name="all-published-content" params=archiveQueryParams>
+        <marko-web-query|{ nodes }| name="website-scheduled-content" params=archiveQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
             primarySection: { canonicalPath: `/${alias}`, name }
@@ -114,7 +118,7 @@ $ const countQueryParams = {
             <@header>On Demand</@header>
           </theme-section-feed-flow>
         </marko-web-query>
-        <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+        <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
           <@query-params ...countQueryParams />
           <theme-pagination-controls
             per-page=perPage

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -96,7 +96,7 @@ $ const countQueryParams = {
           <marko-web-query|{ nodes }| name="website-scheduled-content" params=upcomingQueryParams>
             $ const finalNodes = nodes.map((node) => ({
               ...node,
-              primarySection: { canonicalPath: `/${alias}`, name }
+              primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
             }));
             <theme-section-feed-flow nodes=finalNodes modifiers=["upcoming"]>
               <@header>Upcoming</@header>
@@ -112,7 +112,7 @@ $ const countQueryParams = {
         <marko-web-query|{ nodes }| name="website-scheduled-content" params=archiveQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
-            primarySection: { canonicalPath: `/${alias}`, name }
+            primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
           }));
           <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false>
             <@header>On Demand</@header>

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -1,6 +1,7 @@
 import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
+import handleContentTypePrimarySection from "../../../utils/handle-content-type-primary-section";
 
 $ const { id, alias, description, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
@@ -96,7 +97,7 @@ $ const countQueryParams = {
           <marko-web-query|{ nodes }| name="website-scheduled-content" params=upcomingQueryParams>
             $ const finalNodes = nodes.map((node) => ({
               ...node,
-              primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
+              primarySection: handleContentTypePrimarySection({ i18n, node })
             }));
             <theme-section-feed-flow nodes=finalNodes modifiers=["upcoming"]>
               <@header>Upcoming</@header>
@@ -112,7 +113,7 @@ $ const countQueryParams = {
         <marko-web-query|{ nodes }| name="website-scheduled-content" params=archiveQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
-            primarySection: { canonicalPath: `/${alias}`, name, fullName: name }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
           }));
           <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false>
             <@header>On Demand</@header>

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -1,7 +1,8 @@
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, description, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
 $ const { site, pagination: p, i18n } = out.global;
@@ -15,24 +16,20 @@ $ const queryParams = {
   requiresImage: false,
   sectionBubbling: false,
   includeContentTypes: ["Webinar"],
-
+  queryFragment,
 };
 $ const upcomingQueryParams = {
   ...queryParams,
   beginningAfter: now,
   limit: 25,
-  sort: {
-    field: "startDate",
-    order: "asc",
-  },
+  sortField: "startDate",
+  sortOrder: "asc",
 };
 $ const archiveQueryParams = {
   ...queryParams,
   beginningBefore: now,
-  sort: {
-    field: "startDate",
-    order: "desc",
-  },
+  sortField: "startDate",
+  sortOrder: "desc",
   limit: perPage,
   skip: p.skip({ perPage })
 };
@@ -45,14 +42,9 @@ $ const countQueryParams = {
   },
 };
 
-<global-website-section-default-layout
-  id=id
-  alias=alias
-  name=name
-  page-node=pageNode
->
+<theme-default-page title=name description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
       <@query-params ...countQueryParams />
       <theme-pagination-controls
         per-page=perPage
@@ -62,112 +54,119 @@ $ const countQueryParams = {
       />
     </theme-section-feed-block>
   </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section|{ aliases }| modifiers=["break-container", "first"]>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
 
-  <@section|{ aliases }| modifiers=["break-container", "first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-
-  <@section|{ blockName, section, aliases }|>
-    <if(input.beforeName)>
-      <${input.beforeName}
-        aliases=aliases
-        block-name=blockName
-        section=section
-      />
-    </if>
-  </@section>
-  <@section|{ blockName, section, aliases }| modifiers=["webinars"]>
-    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
-      <if(p.page > 1)>${value}: Page ${p.page}</if>
-      <else>${value}</else>
-    </marko-web-website-section-name>
-    <marko-web-website-section-description obj=section />
-
-    <if(input.afterName)>
-      <${input.afterName}
-        aliases=aliases
-        block-name=blockName
-        section=section
-      />
-    </if>
-    <if(p.page === 1)>
-      <theme-section-feed-block alias=alias modifiers=["upcoming"]>
-        <@header>
-          Upcoming
-        </@header>
-        <@query-params ...upcomingQueryParams />
-        <@after>
-          <theme-gam-define-display-ad
-            name="rotation"
-            position="section_page"
+      <@section|{ blockName, section, aliases }|>
+        <if(input.beforeName)>
+          <${input.beforeName}
             aliases=aliases
-            modifiers=["inter-block"]
+            block-name=blockName
+            section=section
           />
-        </@after>
-      </theme-section-feed-block>
-    </if>
-    <theme-section-feed-block alias=alias lazyload=false modifiers=["archives"]>
-      <@header>
-        On Demand
-      </@header>
-      <@query-params ...archiveQueryParams />
-    </theme-section-feed-block>
-    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
-      <@query-params ...countQueryParams />
-      <theme-pagination-controls
-        per-page=perPage
-        total-count=totalCount
-        path=alias
-      />
-    </theme-section-feed-block>
-  </@section>
+        </if>
+      </@section>
+      <@section|{ blockName, section, aliases }| modifiers=["webinars"]>
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name }>
+          <if(p.page > 1)>${value}: Page ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+        <marko-web-website-section-description obj={ description } />
 
-  <@section>
-    <theme-top-stories-block query-params={ optionName: "Pinned" } />
-  </@section>
+        <if(input.afterName)>
+          <${input.afterName}
+            aliases=aliases
+            block-name=blockName
+            section=section
+          />
+        </if>
+        <if(p.page === 1)>
+          <marko-web-query|{ nodes }| name="all-published-content" params=upcomingQueryParams>
+            $ const finalNodes = nodes.map((node) => ({
+              ...node,
+              primarySection: { canonicalPath: `/${alias}`, name }
+            }));
+            <theme-section-feed-flow nodes=finalNodes modifiers=["upcoming"]>
+              <@header>Upcoming</@header>
+            </theme-section-feed-flow>
+            <theme-gam-define-display-ad
+              name="rotation"
+              position="section_page"
+              aliases=aliases
+              modifiers=["inter-block"]
+            />
+          </marko-web-query>
+        </if>
+        <marko-web-query|{ nodes }| name="all-published-content" params=archiveQueryParams>
+          $ const finalNodes = nodes.map((node) => ({
+            ...node,
+            primarySection: { canonicalPath: `/${alias}`, name }
+          }));
+          <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false>
+            <@header>On Demand</@header>
+          </theme-section-feed-flow>
+        </marko-web-query>
+        <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+          <@query-params ...countQueryParams />
+          <theme-pagination-controls
+            per-page=perPage
+            total-count=totalCount
+            path=alias
+          />
+        </theme-section-feed-block>
+      </@section>
 
-  <@section|{ aliases }|>
-    <theme-native-x-promo-card-block placement-name="marketing" aliases=aliases />
-  </@section>
+      <@section>
+        <theme-top-stories-block query-params={ optionName: "Pinned" } />
+      </@section>
 
-  <@section>
-    $ const defaultParams = {
-        queryParams: { includeContentTypes: ["Product"] },
-        section: { name: "Products", canonicalPath: "/products" },
-    };
-    $ const productsParams = defaultValue(site.get("productsParams"), defaultParams);
-    <theme-content-card-list-block ...productsParams />
-  </@section>
+      <@section|{ aliases }|>
+        <theme-native-x-promo-card-block placement-name="marketing" aliases=aliases />
+      </@section>
 
-  <@section>
-    <global-client-side-most-popular-block />
-  </@section>
+      <@section>
+        $ const defaultParams = {
+            queryParams: { includeContentTypes: ["Product"] },
+            section: { name: "Products", canonicalPath: "/products" },
+        };
+        $ const productsParams = defaultValue(site.get("productsParams"), defaultParams);
+        <theme-content-card-list-block ...productsParams />
+      </@section>
 
-  $ const publicationIds = site.getAsArray("magazine.publicationIds");
-  <if(publicationIds.length)>
-    <@section>
-      <theme-magazine-issues-block publication-id=publicationIds[0] />
-    </@section>
-  </if>
+      <@section>
+        <global-client-side-most-popular-block />
+      </@section>
 
-  <@section>
-    <theme-content-card-deck-block
-      query-params={ includeContentTypes: ["Document"], limit: 4 }
-      section={ name: `${i18n("Downloads")}`, canonicalPath: "/downloads" }
-    />
-  </@section>
+      $ const publicationIds = site.getAsArray("magazine.publicationIds");
+      <if(publicationIds.length)>
+        <@section>
+          <theme-magazine-issues-block publication-id=publicationIds[0] />
+        </@section>
+      </if>
 
-  <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
-</global-website-section-default-layout>
+      <@section>
+        <theme-content-card-deck-block
+          query-params={ includeContentTypes: ["Document"], limit: 4 }
+          section={ name: `${i18n("Downloads")}`, canonicalPath: "/downloads" }
+        />
+      </@section>
+
+      <@section|{ aliases }|>
+        <theme-gam-define-display-ad
+          name="rotation"
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</theme-default-page>

--- a/packages/global/templates/website-section/collections.marko
+++ b/packages/global/templates/website-section/collections.marko
@@ -2,6 +2,7 @@ import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-ali
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
+import handleContentTypePrimarySection from "../../utils/handle-content-type-primary-section";
 
 $ const { site, req, i18n, pagination: p } = out.global;
 $ const { name, description, queryParams: paginationParams } = input;
@@ -47,13 +48,7 @@ $ const queryParams = {
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
                     $ if (["event", "podcast", "webinar"].includes(node.type)) {
-                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
-                      node.primarySection = {
-                        name: `${typeName}s`,
-                        fullName: `${typeName}s`,
-                        alias: `${node.type}s`,
-                        canonicalPath: `/${node.type}s`,
-                      }
+                      node.primarySection = handleContentTypePrimarySection({ i18n, node });
                     }
                     <theme-section-feed-content-node node=node />
                   </@slot>
@@ -85,13 +80,7 @@ $ const queryParams = {
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
                     $ if (["event", "podcast", "webinar"].includes(node.type)) {
-                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
-                      node.primarySection = {
-                        name: `${typeName}s`,
-                        fullName: `${typeName}s`,
-                        alias: `${node.type}s`,
-                        canonicalPath: `/${node.type}s`,
-                      }
+                      node.primarySection = handleContentTypePrimarySection({ i18n, node });
                     }
                     <theme-section-feed-content-node node=node />
                   </@slot>
@@ -130,13 +119,7 @@ $ const queryParams = {
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
                     $ if (["event", "podcast", "webinar"].includes(node.type)) {
-                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
-                      node.primarySection = {
-                        name: `${typeName}s`,
-                        fullName: `${typeName}s`,
-                        alias: `${node.type}s`,
-                        canonicalPath: `/${node.type}s`,
-                      }
+                      node.primarySection = handleContentTypePrimarySection({ i18n, node });
                     }
                     <theme-section-feed-content-node node=node />
                   </@slot>
@@ -168,13 +151,7 @@ $ const queryParams = {
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
                     $ if (["event", "podcast", "webinar"].includes(node.type)) {
-                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
-                      node.primarySection = {
-                        name: `${typeName}s`,
-                        fullName: `${typeName}s`,
-                        alias: `${node.type}s`,
-                        canonicalPath: `/${node.type}s`,
-                      }
+                      node.primarySection = handleContentTypePrimarySection({ i18n, node });
                     }
                     <theme-section-feed-content-node node=node />
                   </@slot>

--- a/packages/global/templates/website-section/collections.marko
+++ b/packages/global/templates/website-section/collections.marko
@@ -46,6 +46,15 @@ $ const queryParams = {
               >
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
+                    $ if (["event", "podcast", "webinar"].includes(node.type)) {
+                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
+                      node.primarySection = {
+                        name: `${typeName}s`,
+                        fullName: `${typeName}s`,
+                        alias: `${node.type}s`,
+                        canonicalPath: `/${node.type}s`,
+                      }
+                    }
                     <theme-section-feed-content-node node=node />
                   </@slot>
                 </@nodes>
@@ -75,6 +84,15 @@ $ const queryParams = {
               >
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
+                    $ if (["event", "podcast", "webinar"].includes(node.type)) {
+                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
+                      node.primarySection = {
+                        name: `${typeName}s`,
+                        fullName: `${typeName}s`,
+                        alias: `${node.type}s`,
+                        canonicalPath: `/${node.type}s`,
+                      }
+                    }
                     <theme-section-feed-content-node node=node />
                   </@slot>
                 </@nodes>
@@ -111,6 +129,15 @@ $ const queryParams = {
               >
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
+                    $ if (["event", "podcast", "webinar"].includes(node.type)) {
+                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
+                      node.primarySection = {
+                        name: `${typeName}s`,
+                        fullName: `${typeName}s`,
+                        alias: `${node.type}s`,
+                        canonicalPath: `/${node.type}s`,
+                      }
+                    }
                     <theme-section-feed-content-node node=node />
                   </@slot>
                 </@nodes>
@@ -140,6 +167,15 @@ $ const queryParams = {
               >
                 <@nodes nodes=nodes>
                   <@slot|{ node }|>
+                    $ if (["event", "podcast", "webinar"].includes(node.type)) {
+                      const typeName = `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}`;
+                      node.primarySection = {
+                        name: `${typeName}s`,
+                        fullName: `${typeName}s`,
+                        alias: `${node.type}s`,
+                        canonicalPath: `/${node.type}s`,
+                      }
+                    }
                     <theme-section-feed-content-node node=node />
                   </@slot>
                 </@nodes>

--- a/packages/global/templates/website-section/events.marko
+++ b/packages/global/templates/website-section/events.marko
@@ -1,8 +1,3 @@
-$ const { id, alias, name, pageNode } = input;
+$ const { alias, description, name } = input;
 
-<global-website-section-events-feed-layout
-  id=id
-  alias=alias
-  name=name
-  page-node=pageNode
-/>
+<global-website-section-events-feed-layout alias=alias description=description name=name />

--- a/packages/global/templates/website-section/webinars.marko
+++ b/packages/global/templates/website-section/webinars.marko
@@ -1,8 +1,3 @@
-$ const { id, alias, name, pageNode } = input;
+$ const { alias, description, name } = input;
 
-<global-website-section-webinars-feed-layout
-  id=id
-  alias=alias
-  name=name
-  page-node=pageNode
-/>
+<global-website-section-webinars-feed-layout alias=alias description=description name=name />

--- a/packages/global/templates/website-section/with-top-stories-block.marko
+++ b/packages/global/templates/website-section/with-top-stories-block.marko
@@ -82,10 +82,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
@@ -108,10 +105,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
@@ -138,10 +132,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />
@@ -165,10 +156,7 @@ $ const queryParams = {
       $ const finalNodes = nodes.map((node) => ({
         ...node,
         ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
-          primarySection: {
-            canonicalPath: `/${node.type}s`,
-            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
-            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+            primarySection: handleContentTypePrimarySection({ i18n, node })
         }),
       }));
      <theme-section-feed-flow nodes=finalNodes lazyload=false />

--- a/packages/global/templates/website-section/with-top-stories-block.marko
+++ b/packages/global/templates/website-section/with-top-stories-block.marko
@@ -1,3 +1,4 @@
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
@@ -11,6 +12,11 @@ $ const buttonLabels = { continue: continueLabel };
 $ const perPage = 15;
 $ const actionText = i18n("signing up to receive your email notifications");
 $ const baseSkip = p.page === 1 ? 2 : 0;
+$ const queryParams = {
+  sectionAlias: alias,
+  limit: 3,
+  queryFragment
+};
 
 <global-website-section-default-layout
   id=id
@@ -71,9 +77,19 @@ $ const baseSkip = p.page === 1 ? 2 : 0;
       />
     </if>
     <else>
-      <theme-section-feed-block alias=alias lazyload=false>
-        <@query-params limit=3 skip=p.skip({ perPage, skip: baseSkip }) />
-      </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: baseSkip });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
     </else>
   </@section>
 
@@ -87,9 +103,19 @@ $ const baseSkip = p.page === 1 ? 2 : 0;
   </@section>
 
   <@section>
-    <theme-section-feed-block alias=alias lazyload=false>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: baseSkip + 3 }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: baseSkip + 3});
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
   </@section>
 
   <@section>
@@ -107,9 +133,19 @@ $ const baseSkip = p.page === 1 ? 2 : 0;
   </@section>
 
   <@section>
-    <theme-section-feed-block alias=alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: baseSkip + 6 }) />
-    </theme-section-feed-block>
+    $ queryParams.skip = p.skip({ perPage, skip: baseSkip + 6 });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
   </@section>
 
   <@section|{ aliases }|>
@@ -123,9 +159,20 @@ $ const baseSkip = p.page === 1 ? 2 : 0;
 
   <@section>
     $ const blockLimit = p.page === 1 ? 4 : 3;
-    <theme-section-feed-block alias=alias>
-      <@query-params limit=blockLimit skip=p.skip({ perPage, skip: baseSkip + 9 }) />
-    </theme-section-feed-block>
+    $ queryParams.limit = blockLimit;
+    $ queryParams.skip = p.skip({ perPage, skip: baseSkip + 9 });
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+      $ const finalNodes = nodes.map((node) => ({
+        ...node,
+        ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+          primarySection: {
+            canonicalPath: `/${node.type}s`,
+            name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+            fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+        }),
+      }));
+     <theme-section-feed-flow nodes=finalNodes lazyload=false />
+    </marko-web-query>
     <if(p.page === 1)>
       <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
         <theme-pagination-controls
@@ -148,9 +195,19 @@ $ const baseSkip = p.page === 1 ? 2 : 0;
 
   <@section>
     <if(p.page !== 1)>
-      <theme-section-feed-block alias=alias>
-        <@query-params limit=3 skip=p.skip({ perPage, skip: baseSkip + 12 }) />
-      </theme-section-feed-block>
+      $ queryParams.skip = p.skip({ perPage, skip: baseSkip + 12 });
+      <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+        $ const finalNodes = nodes.map((node) => ({
+          ...node,
+          ...((node.type && ['event', 'podcast', 'webinar'].includes(node.type)) &&  {
+            primarySection: {
+              canonicalPath: `/${node.type}s`,
+              name: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s`,
+              fullName: `${node.type.slice(0,1).toUpperCase()}${node.type.slice(1)}s` }
+          }),
+        }));
+      <theme-section-feed-flow nodes=finalNodes lazyload=false />
+      </marko-web-query>
     </if>
   </@section>
 

--- a/packages/global/utils/handle-content-type-primary-section.js
+++ b/packages/global/utils/handle-content-type-primary-section.js
@@ -1,0 +1,16 @@
+module.exports = ({ i18n, node }) => {
+  if (node.type) {
+    const typeName = `${node.type.slice(0, 1).toUpperCase()}${node.type.slice(1)}`;
+    const name = `${typeName}s`;
+    const fullName = name;
+    const alias = `${node.type}s`;
+    const canonicalPath = `/${i18n(alias)}`;
+    return {
+      name: `${i18n(name)}`,
+      fullName: `${i18n(fullName)}`,
+      alias: `${i18n(alias)}`,
+      canonicalPath,
+    };
+  }
+  return node.primarySection;
+};

--- a/sites/healthcarepackaging.com/server/routes/scheduled-content.js
+++ b/sites/healthcarepackaging.com/server/routes/scheduled-content.js
@@ -22,4 +22,15 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/supplier-news', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'supplier-news',
+        includeLabels: ['Supplier Submitted'],
+        title: 'Supplier News',
+        withSection: true,
+      },
+    );
+  });
 };

--- a/sites/healthcarepackaging.com/server/routes/website-section.js
+++ b/sites/healthcarepackaging.com/server/routes/website-section.js
@@ -31,14 +31,17 @@ module.exports = (app) => {
     },
   })));
 
-  app.get('/:alias(events)', withWebsiteSection({
-    template: events,
-    queryFragment,
-  }));
-  app.get('/:alias(webinars)', withWebsiteSection({
-    template: webinars,
-    queryFragment,
-  }));
+  app.get('/events', asyncRoute(async (_, res) => res.marko(events, {
+    alias: 'events',
+    name: 'Events',
+    description: 'Connect with healthcare packaging professionals, gain insights into the latest trends, and experience breakthrough technologies.',
+  })));
+
+  app.get('/webinars', asyncRoute(async (_, res) => res.marko(webinars, {
+    alias: 'webinars',
+    name: 'Webinars',
+    description: 'Industry experts talk medical packaging technologies, sustainability, and logistics, ranging from fill/finish, package design, automation, and temperature control.',
+  })));
 
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,

--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -5,96 +5,84 @@ $ const { id, alias, name, pageNode } = input;
 
 $ const { site } = out.global;
 
-$ const queryParams = {
-  sectionAlias: 'supplier-news',
-  limit: 10000,
-  queryFragment,
-};
-
-<marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-  $ const excludeContentIds = nodes.map((node) =>  node.id);
-  <global-website-section-home-layout
-    id=id
-    alias=alias
-    name=name
-    page-node=pageNode
-  >
-    <@section>
-      <div class="row">
-        <div class="col-lg-8">
-          <global-leaders-home-page />
-        </div>
-        <div class="col-lg-4">
-          <global-native-x-list-block />
-        </div>
+<global-website-section-home-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@section>
+    <div class="row">
+      <div class="col-lg-8">
+        <global-leaders-home-page />
       </div>
-    </@section>
+      <div class="col-lg-4">
+        <global-native-x-list-block />
+      </div>
+    </div>
+  </@section>
 
+  <@section>
+    <marko-web-deferred-script-loader-register
+      name="credspark-hcp-home"
+      src="https://app.credspark.com/assessments/community-poll-answer-to-see-how-others-answered-421f60b76653d/embed_script.js"
+      on="load"
+      request-frame=true
+      target-tag="head"
+    />
+    <div id="credsparkQuiz" class="credsparkQuiz" data-quiz-id="community-poll-answer-to-see-how-others-answered-421f60b76653d"></div>
+  </@section>
+
+  <@section>
+    <global-published-content-list-deck-block section-ids=[33324, 33333, 33338] />
+  </@section>
+
+  <@section|{ aliases }|>
+    <theme-gam-define-display-ad
+      name="rotation"
+      position="home_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <theme-content-card-list-block
+      query-params={ includeContentTypes: ["Product"] }
+      section={ name: "Products", canonicalPath: "/products" }
+    />
+  </@section>
+
+  <@section>
+    <theme-section-feed-block alias="home">
+      <@before><div class="node-list__header" style="padding: 0px">More from Healthcare Packaging</div></@before>
+      <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted"] />
+    </theme-section-feed-block>
+  </@section>
+
+  $ const publicationIds = site.getAsArray("magazine.publicationIds");
+  <if(publicationIds.length)>
     <@section>
-      <marko-web-deferred-script-loader-register
-        name="credspark-hcp-home"
-        src="https://app.credspark.com/assessments/community-poll-answer-to-see-how-others-answered-421f60b76653d/embed_script.js"
-        on="load"
-        request-frame=true
-        target-tag="head"
-      />
-      <div id="credsparkQuiz" class="credsparkQuiz" data-quiz-id="community-poll-answer-to-see-how-others-answered-421f60b76653d"></div>
+      <theme-magazine-issues-block publication-id=publicationIds[0] />
     </@section>
+  </if>
 
-    <@section>
-      <global-published-content-list-deck-block
-        section-ids=[33324, 33333, 33338]
-        exclude-content-ids=excludeContentIds
-      />
-    </@section>
+  <@section>
+    <marko-web-identity-x-context|{ hasUser }|>
+      <if(!hasUser)>
+        <identity-x-newsletter-form-inline
+          login-email-label="Work Email"
+          login-email-placeholder="example@yourcompany.com"
+          type="inlineSection"
+        />
+      </if>
+    </marko-web-identity-x-context>
+  </@section>
 
-    <@section|{ aliases }|>
-      <theme-gam-define-display-ad
-        name="rotation"
-        position="home_page"
-        aliases=aliases
-        modifiers=["inter-block"]
-      />
-    </@section>
-
-    <@section>
-      <theme-content-card-list-block
-        query-params={ includeContentTypes: ["Product"] }
-        section={ name: "Products", canonicalPath: "/products" }
-      />
-    </@section>
-
-    <@section>
-      <theme-section-feed-block alias="home">
-        <@before><div class="node-list__header" style="padding: 0px">More from Healthcare Packaging</div></@before>
-        <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted"] exclude-content-ids=excludeContentIds />
-      </theme-section-feed-block>
-    </@section>
-
-    $ const publicationIds = site.getAsArray("magazine.publicationIds");
-    <if(publicationIds.length)>
-      <@section>
-        <theme-magazine-issues-block publication-id=publicationIds[0] />
-      </@section>
-    </if>
-
-    <@section>
-      <marko-web-identity-x-context|{ hasUser }|>
-        <if(!hasUser)>
-          <identity-x-newsletter-form-inline
-            login-email-label="Work Email"
-            login-email-placeholder="example@yourcompany.com"
-            type="inlineSection"
-          />
-        </if>
-      </marko-web-identity-x-context>
-    </@section>
-
-    <@section>
-      <theme-content-card-deck-block
-        query-params={ includeContentTypes: ["Document"], limit: 4 }
-        section={ name: "Downloads", canonicalPath: "/downloads" }
-      />
-    </@section>
-  </global-website-section-home-layout>
-</marko-web-query>
+  <@section>
+    <theme-content-card-deck-block
+      query-params={ includeContentTypes: ["Document"], limit: 4 }
+      section={ name: "Downloads", canonicalPath: "/downloads" }
+    />
+  </@section>
+</global-website-section-home-layout>

--- a/sites/mundopmmi.com/config/i18n.js
+++ b/sites/mundopmmi.com/config/i18n.js
@@ -89,4 +89,6 @@ module.exports = {
   'your email helps us uphold our standards of quality content. unlock full access to our articles with a quick submission.': 'Su correo electrónico nos ayuda a mantener nuestros estándares de contenido de calidad. Desbloquee el acceso completo a nuestros artículos con un envío rápido.',
   continue: 'Continuar',
   recommended: 'Recomendado',
+  events: 'eventos',
+  webinars: 'seminario-web',
 };

--- a/sites/mundopmmi.com/server/routes/website-section.js
+++ b/sites/mundopmmi.com/server/routes/website-section.js
@@ -19,14 +19,18 @@ module.exports = (app) => {
       includeTaxonomyIds: [3199357],
     },
   })));
-  app.get('/:alias(eventos)', withWebsiteSection({
-    template: events,
-    queryFragment,
-  }));
-  app.get('/:alias(seminario-web)', withWebsiteSection({
-    template: webinars,
-    queryFragment,
-  }));
+
+  app.get('/eventos', asyncRoute(async (_, res) => res.marko(events, {
+    alias: 'eventos',
+    name: 'Eventos',
+    description: 'Acceda aquí a información clave de las principales ferias, seminarios y eventos internacionales dirigidos a profesionales de las industrias de envasado, procesamiento de alimentos y bebidas, y automatización.',
+  })));
+
+  app.get('/seminario-web', asyncRoute(async (_, res) => res.marko(webinars, {
+    alias: 'seminario-web',
+    name: 'Seminario Web',
+    description: 'Perspectivas y análisis de líderes de opinión sobre tecnologías y tendencias de mercado en las industrias de envasado, procesamiento de alimentos y bebidas, y automatización.',
+  })));
 
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,

--- a/sites/oemmagazine.org/server/routes/scheduled-content.js
+++ b/sites/oemmagazine.org/server/routes/scheduled-content.js
@@ -12,4 +12,15 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/supplier-news', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'supplier-news',
+        includeLabels: ['Supplier Submitted'],
+        title: 'Supplier News',
+        withSection: true,
+      },
+    );
+  });
 };

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -5,6 +5,7 @@ const leadersFragment = require('@pmmi-media-group/package-global/graphql/fragme
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const events = require('@pmmi-media-group/package-global/templates/website-section/events');
 const collections = require('@pmmi-media-group/package-global/templates/website-section/collections');
+const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const withTopStoriesBlock = require('@pmmi-media-group/package-global/templates/website-section/with-top-stories-block');
 
 const section = require('../templates/website-section');
@@ -21,10 +22,18 @@ module.exports = (app) => {
     },
   })));
 
-  app.get('/:alias(events)', withWebsiteSection({
-    template: events,
-    queryFragment,
-  }));
+  app.get('/events', asyncRoute(async (_, res) => res.marko(events, {
+    alias: 'events',
+    name: 'Events',
+    description: '',
+  })));
+
+  app.get('/webinars', asyncRoute(async (_, res) => res.marko(webinars, {
+    alias: 'webinars',
+    name: 'Webinars',
+    description: '',
+  })));
+
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/oemmagazine.org/server/templates/index.marko
+++ b/sites/oemmagazine.org/server/templates/index.marko
@@ -23,18 +23,7 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    $ const queryParams = {
-      sectionAlias: 'supplier-news',
-      limit: 500,
-      queryFragment,
-    };
-    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-      $ const excludeContentIds = nodes.map((node) =>  node.id);
-      <global-published-content-list-deck-block
-        section-ids=[33367, 33377, 33379]
-        exclude-content-ids=excludeContentIds
-      />
-    </marko-web-query>
+    <global-published-content-list-deck-block section-ids=[33367, 33377, 33379] />
   </@section>
 
   <@section|{ aliases }|>

--- a/sites/packworld.com/server/routes/scheduled-content.js
+++ b/sites/packworld.com/server/routes/scheduled-content.js
@@ -32,4 +32,15 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/supplier-news', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'supplier-news',
+        includeLabels: ['Supplier Submitted'],
+        title: 'Supplier News',
+        withSection: true,
+      },
+    );
+  });
 };

--- a/sites/packworld.com/server/routes/website-section.js
+++ b/sites/packworld.com/server/routes/website-section.js
@@ -108,15 +108,17 @@ module.exports = (app) => {
     },
   })));
 
-  app.get('/:alias(events)', withWebsiteSection({
-    template: events,
-    queryFragment,
-  }));
+  app.get('/events', asyncRoute(async (_, res) => res.marko(events, {
+    alias: 'events',
+    name: 'Events',
+    description: 'Connect with industry leaders, gain insights into the latest trends, and experience breakthrough technologies in packaging and processing.',
+  })));
 
-  app.get('/:alias(webinars)', withWebsiteSection({
-    template: webinars,
-    queryFragment,
-  }));
+  app.get('/webinars', asyncRoute(async (_, res) => res.marko(webinars, {
+    alias: 'webinars',
+    name: 'Webinars',
+    description: 'Packaging webinars cover equipment, machinery, design, materials, sustainability, e-commerce, workforce, regulation, innovation, cannabis, & logistics.',
+  })));
 
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,

--- a/sites/packworld.com/server/templates/index.marko
+++ b/sites/packworld.com/server/templates/index.marko
@@ -23,18 +23,7 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    $ const queryParams = {
-      sectionAlias: 'supplier-news',
-      limit: 500,
-      queryFragment,
-    };
-    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-      $ const excludeContentIds = nodes.map((node) =>  node.id);
-      <global-published-content-list-deck-block
-        section-ids=[33249, 33256, 33261]
-        exclude-content-ids=excludeContentIds
-      />
-    </marko-web-query>
+    <global-published-content-list-deck-block section-ids=[33249, 33256, 33261] />
   </@section>
 
   <@section|{ aliases }|>

--- a/sites/profoodworld.com/server/routes/scheduled-content.js
+++ b/sites/profoodworld.com/server/routes/scheduled-content.js
@@ -22,4 +22,15 @@ module.exports = (app) => {
       },
     );
   });
+  app.get('/supplier-news', newsletterState(), (_, res) => {
+    res.marko(
+      scheduledContent,
+      {
+        alias: 'supplier-news',
+        includeLabels: ['Supplier Submitted'],
+        title: 'Supplier News',
+        withSection: true,
+      },
+    );
+  });
 };

--- a/sites/profoodworld.com/server/routes/website-section.js
+++ b/sites/profoodworld.com/server/routes/website-section.js
@@ -27,15 +27,17 @@ module.exports = (app) => {
   app.get('/:alias(global-50)', newsletterState(), (_, res) => { res.marko(global50); });
   app.get('/:alias(global-50/*)', newsletterState(), (_, res) => { res.marko(global50); });
 
-  app.get('/:alias(events)', withWebsiteSection({
-    template: events,
-    queryFragment,
-  }));
+  app.get('/events', asyncRoute(async (_, res) => res.marko(events, {
+    alias: 'events',
+    name: 'Events',
+    description: 'Connect with industry leaders, gain insights into the latest trends, and experience breakthrough technologies in food processing & packaging.',
+  })));
 
-  app.get('/:alias(webinars)', withWebsiteSection({
-    template: webinars,
-    queryFragment,
-  }));
+  app.get('/webinars', asyncRoute(async (_, res) => res.marko(webinars, {
+    alias: 'webinars',
+    name: 'Webinars',
+    description: 'Industry expert insights on technologies, equipment, and software for food and beverage manufacturing.',
+  })));
 
   app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
     template: leaders,

--- a/sites/profoodworld.com/server/templates/index.marko
+++ b/sites/profoodworld.com/server/templates/index.marko
@@ -23,18 +23,7 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    $ const queryParams = {
-      sectionAlias: 'supplier-news',
-      limit: 500,
-      queryFragment,
-    };
-    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-      $ const excludeContentIds = nodes.map((node) =>  node.id);
-      <global-published-content-list-deck-block
-        section-ids=[33406, 33417, 33424]
-        exclude-content-ids=excludeContentIds
-      />
-    </marko-web-query>
+    <global-published-content-list-deck-block section-ids=[33406, 33417, 33424] />
   </@section>
 
   <@section|{ aliases }|>


### PR DESCRIPTION
Goal here is multifold:

1. Anywhere a Podcast, Webinar or Event is listed it's slug/breadcrumb should be set to it's respective landing page (`/podcasts`, `/webinars`, `/events` respectively).
2. Supplier News will be label driven, for the moment the previous Supplier News sections have not been removed however the queries to exclude this content from the homepages have been as the idea would be that all the blocks on the homepage already exclude content by labels (Namely the Supplier Submitted one that I believe is what this is supposed to use, although this can be added onto or changed as need be both for the exclusion and the page itself).
3. Adding onto 2, the Supplier News section page is now populated using the `Supplier Submitted` label and can be swapped out and/or added onto if need be.


Barrage of screenshots showing impacted pages:

![Screenshot from 2024-04-10 12-29-24](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/ecc9bdff-922e-4b98-ba7d-e68d9dc54222)
![Screenshot from 2024-04-10 12-29-33](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/4927ed01-b1a2-46e9-bec5-e1138e97ba87)
![Screenshot from 2024-04-10 12-29-42](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/e67e1371-5035-45bb-95b6-39413464b8f7)
![Screenshot from 2024-04-10 12-29-48](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/48ada70e-a0a5-4371-b089-503d71c49b37)
![Screenshot from 2024-04-10 12-30-32](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/bd9e5549-c04e-4b82-95eb-d8ca14b27680)
![Screenshot from 2024-04-10 12-30-41](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/5bbda8eb-da8d-441f-bbe3-6ede72f5dfa3)
![Screenshot from 2024-04-10 12-32-39](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/74901c91-2ca7-4773-9c1a-3909042681dd)
![Screenshot from 2024-04-10 12-33-42](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/3ebcb8e2-05ab-49a7-9e90-6d61c692711f)
![Screenshot from 2024-04-10 12-43-35](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/91471b08-ac17-4cd6-8157-e0955521676a)
![Screenshot from 2024-04-10 12-43-51](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/4b7b7a69-44a8-4707-9ae3-015cff8f1542)
![Screenshot from 2024-04-10 12-44-03](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/4ddb35a2-2b5c-4606-b15b-a6ed41c3e7b0)
![Screenshot from 2024-04-10 12-44-19](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/03ddf5ad-d020-4b32-8c6d-2e07d4d8a766)
![Screenshot from 2024-04-10 13-47-32](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/b3e577e8-fdeb-45c9-9318-650c47587773)
![Screenshot from 2024-04-10 14-04-51](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/cbec7e14-5696-488a-a9aa-d771ec1dfd93)
![Screenshot from 2024-04-10 15-09-54](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/caa4ba68-e975-4e80-addb-6cc71889febf)
![Screenshot from 2024-04-10 15-13-15](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/d51aad5b-5239-45c9-a9d6-d1295e397707)
![Screenshot from 2024-04-10 15-14-09](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/2537b4c4-0fb6-4612-8032-29f08b0230f2)
