### PR TITLE
Forcibly hardset the SEO title for Leaders section pages to be Leaders

### DIFF
--- a/packages/global/components/layouts/website-section/leaders.marko
+++ b/packages/global/components/layouts/website-section/leaders.marko
@@ -1,11 +1,11 @@
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 $ const { GAM, site, config } = out.global;
 
-<theme-website-section-page id=id alias=alias name=name>
+<theme-website-section-page id=id alias=alias name="Leaders">
   <@head>
     <marko-web-gtm-website-section-context|{ context }| alias=alias>
       <marko-web-gtm-push data=context />

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -16,7 +16,6 @@
     "@sections <section>[]": {},
     "@id": "number",
     "@alias": "string",
-    "@name": "string",
     "@page-node": "object"
   },
   "<global-website-section-feed-layout>": {

--- a/sites/healthcarepackaging.com/server/templates/website-section/leaders.marko
+++ b/sites/healthcarepackaging.com/server/templates/website-section/leaders.marko
@@ -1,13 +1,12 @@
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 
 $ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
-  name=name
   page-node=pageNode
 >
   <@page-description>

--- a/sites/mundopmmi.com/server/templates/website-section/leaders.marko
+++ b/sites/mundopmmi.com/server/templates/website-section/leaders.marko
@@ -1,13 +1,12 @@
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 
 $ const { site } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
-  name=name
   page-node=pageNode
 >
  <@page-description>

--- a/sites/oemmagazine.org/server/templates/website-section/leaders.marko
+++ b/sites/oemmagazine.org/server/templates/website-section/leaders.marko
@@ -1,13 +1,12 @@
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 
 $ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
-  name=name
   page-node=pageNode
 >
   <@page-description>

--- a/sites/packworld.com/server/templates/website-section/leaders.marko
+++ b/sites/packworld.com/server/templates/website-section/leaders.marko
@@ -1,13 +1,12 @@
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 
 $ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
-  name=name
   page-node=pageNode
 >
   <@page-description>

--- a/sites/profoodworld.com/server/templates/website-section/leaders.marko
+++ b/sites/profoodworld.com/server/templates/website-section/leaders.marko
@@ -1,13 +1,12 @@
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { id, alias, name, pageNode } = input;
+$ const { id, alias, pageNode } = input;
 
 $ const { site, config } = out.global;
 
 <global-website-section-leaders-layout
   id=id
   alias=alias
-  name=name
   page-node=pageNode
 >
   <@page-description>


### PR DESCRIPTION
This isn't currently going to look like anything has changed as all the site sections are called Leaders but due to incoming request to force the leaders section to the bottom (potentially ultimately soft deleting it and using another section to take it's place with the same alias), this needs to be done in order to assure changing the name doesn't change the SEO title as that's the only place it's truly being used.