### PR TITLE
Webinars corrections STAGING

### DIFF
--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -23,18 +23,14 @@ $ const upcomingQueryParams = {
   ...queryParams,
   beginningAfter: now,
   limit: 25,
-  sort: {
-    field: "startDate",
-    order: "asc",
-  }
+  sortField: "startDate",
+  sortOrder: "desc",
 };
 $ const archiveQueryParams = {
   ...queryParams,
   beginningBefore: now,
-  sort: {
-    field: "startDate",
-    order: "desc",
-  },
+  sortField: "startDate",
+  sortOrder: "desc",
   limit: perPage,
   skip: p.skip({ perPage })
 };
@@ -49,7 +45,7 @@ $ const countQueryParams = {
 
 <theme-default-page title=name description=description>
   <@head>
-    <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
       <@query-params ...countQueryParams />
       <theme-pagination-controls
         per-page=perPage
@@ -94,7 +90,7 @@ $ const countQueryParams = {
           />
         </if>
         <if(p.page === 1)>
-          <marko-web-query|{ nodes }| name="website-scheduled-content" params=upcomingQueryParams>
+          <marko-web-query|{ nodes }| name="all-published-content" params=upcomingQueryParams>
             $ const finalNodes = nodes.map((node) => ({
               ...node,
               primarySection: handleContentTypePrimarySection({ i18n, node })
@@ -110,16 +106,16 @@ $ const countQueryParams = {
             />
           </marko-web-query>
         </if>
-        <marko-web-query|{ nodes }| name="website-scheduled-content" params=archiveQueryParams>
+        <marko-web-query|{ nodes }| name="all-published-content" params=archiveQueryParams>
           $ const finalNodes = nodes.map((node) => ({
             ...node,
             primarySection: handleContentTypePrimarySection({ i18n, node })
           }));
-          <theme-section-feed-flow nodes=finalNodes modifiers=["archives"] lazyload=false>
+          <theme-section-feed-flow nodes=finalNodes lazyload=false>
             <@header>On Demand</@header>
           </theme-section-feed-flow>
         </marko-web-query>
-        <theme-section-feed-block|{ totalCount }| count-only=true query-name="website-scheduled-content">
+        <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
           <@query-params ...countQueryParams />
           <theme-pagination-controls
             per-page=perPage

--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -60,6 +60,7 @@ const primaryNavigationItems = [
   ...topics,
   { href: '/leaders', label: 'Partner Leaders' },
   { href: '/downloads', label: 'Downloads' },
+  { href: '/webinars', label: 'Webinars' },
 ];
 
 module.exports = {


### PR DESCRIPTION
Assure only site primary webinars are shown (use all-published-content over website-scheduled-content query):
![Screenshot from 2024-05-10 10-13-55](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/97d3daa3-80a0-4471-9350-bb8013e63918)

Webinars in navigation and On-Demand header shown regardless of whether or not there are any upcoming webinars
![Screenshot from 2024-05-10 10-13-51](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/717a2d75-b322-48eb-8161-ff500ede136b)

On-Demand header shown regardless of whether or not there are any upcoming webinars
![Screenshot from 2024-05-10 10-14-54](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/3371d08e-c168-4c91-9315-2d76283d0fb3)
