### PR TITLE
Additional Newsletter Signup on content pages PFW

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -99,6 +99,21 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
           print-path=`/print/content/${content.id}`
         />
       </if>
+      <marko-web-identity-x-context|{ hasUser }|>
+        <if(!hasUser && Object.keys(site.getAsObject(`newsletter.socialShareReplacementBanner`)).length)>
+          <div class="newsletter-signup-banner-social-share-replace">
+            <identity-x-newsletter-form-inline
+              button-labels=buttonLabels
+              login-email-label=loginEmailLabel
+              login-email-placeholder="example@yourcompany.com"
+              type="inlineContent"
+              action-text=actionText
+              with-image=false
+              config-name="socialShareReplacementBanner"
+            />
+          </div>
+        </if>
+      </marko-web-identity-x-context>
     </div>
   </@section>
 

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -550,4 +550,30 @@ label {
     top: 1rem;
   }
 }
+
+.newsletter-signup-banner-social-share-replace {
+  form {
+    display: flex;
+    flex-wrap: wrap;
+    .form-group {
+      flex: 1;
+      flex-grow: 1;
+      max-width: 318px;
+       ~ .btn {
+        align-self: flex-start;
+       }
+    }
+  }
+  label[for="sign-on-email"] {
+    display: none;
+  }
+  .btn {
+    flex-shrink: 1;
+    margin-left: map-get($spacers, 3);
+    padding: 10px;
+    font-weight: $font-weight-bolder;
+    order: 2;
+    align-self: center;
+  }
+}
 /*! critical:end */

--- a/sites/profoodworld.com/config/newsletter.js
+++ b/sites/profoodworld.com/config/newsletter.js
@@ -29,4 +29,9 @@ module.exports = {
     name: 'You\'re Invited!',
     description: 'Don\'t miss your weekly dose of packaging intelligence and news with <strong>ProFood World\'s</strong> e-newsletter.',
   },
+  socialShareReplacementBanner: {
+    ...defaults,
+    name: ' ',
+    description: 'Thanks for stopping by! Get our top stories delivered daily by subscribing.',
+  },
 };


### PR DESCRIPTION
![image](https://github.com/parameter1/pmmi-media-group-websites/assets/46794001/36f9ef2c-c8a5-4ff9-b09a-c50f2d3e5e01)


Opted not to remove the social icons as this couldn't just slide "inline" given the additional text etc. if they decide removing those icons is still necessary that can be done separately.