### PR TITLE
Always use content schedules for determining contextual leaders

### DIFF
--- a/packages/global/components/leaders/contextual.marko
+++ b/packages/global/components/leaders/contextual.marko
@@ -1,9 +1,6 @@
 $ const { site, req } = out.global;
 $ const { contentId } = input;
 
-// @todo Utilize site.get("lang") === "es" to determine this once all sites have launched for 2024
-$ const useContentSchedules = site.get("leaders.alias") === 'company-categories-2024' ? true : false;
-
 <if(contentId && site.get("leaders.enabled"))>
   <marko-web-leaders props={
     contentId,
@@ -16,7 +13,7 @@ $ const useContentSchedules = site.get("leaders.alias") === 'company-categories-
     offsetTop: 50,
     viewAllHref: '/leaders',
     columns: 1,
-    useContentSchedules,
+    useContentSchedules: true,
     calloutPrefix: site.get("leaders.calloutPrefix") || "Browse these",
     calloutValue: site.get("leaders.calloutValue") || "leading suppliers",
     viewAllText: site.get("leaders.viewAllText") || "View All Companies &gt;",


### PR DESCRIPTION
Mundo is the last site that needed to have this changed over (hence the removed todo to use site language to determine when to do this that was never ultimately updated when the English sites all got converted), this will therefore be using the respective UNVERSAL TAXONOMY (SITE_CODE_GOES_HERE) schedules to determine what Leaders context (if there is one) to load.


PRODUCTION:
![Screenshot from 2024-09-10 10-24-06](https://github.com/user-attachments/assets/d48cf633-8e20-4499-a4e7-3101bbd653d4)

DEVELOPMENT:
![Screenshot from 2024-09-10 10-24-19](https://github.com/user-attachments/assets/9b00dcb4-0718-4955-970b-86002ccffb49)
