### PR TITLE
Add simple regex & orgBody check to account for <script>

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -181,16 +181,20 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
                     preventHTMLInjection: !shouldInjectAds,
                     $global
                   });
-                  $ const { partOne, partTwo } = splitContentBody({ body: contentBodyWithInjections });
+                  $ const { partOne, partTwo } = splitContentBody({ body: content.body, contentBodyWithInjections });
                   <marko-web-content-body block-name=blockName obj={ body: partOne } />
-                  <div id="content-page-preview-overlay" class="content-page-preview-overlay" />
-                  <marko-web-browser-component name="GlobalStoryContinuesButton" />
-                  <marko-web-content-body
-                    block-name=blockName
-                    obj={ body: partTwo }
-                    attrs={ style: "display: none;", id: "content-body-part-two" }
-                    modifiers=["ld-json"]
-                  />
+
+                  <if(partTwo)>
+                  $ console.log('partTwo: ')
+                    <div id="content-page-preview-overlay" class="content-page-preview-overlay" />
+                    <marko-web-browser-component name="GlobalStoryContinuesButton" />
+                    <marko-web-content-body
+                      block-name=blockName
+                      obj={ body: partTwo }
+                      attrs={ style: "display: none;", id: "content-body-part-two" }
+                      modifiers=["ld-json"]
+                    />
+                  </if>
                 </if>
                 <else>
                   <theme-body-with-injection

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -183,9 +183,7 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
                   });
                   $ const { partOne, partTwo } = splitContentBody({ body: content.body, contentBodyWithInjections });
                   <marko-web-content-body block-name=blockName obj={ body: partOne } />
-
                   <if(partTwo)>
-                  $ console.log('partTwo: ')
                     <div id="content-page-preview-overlay" class="content-page-preview-overlay" />
                     <marko-web-browser-component name="GlobalStoryContinuesButton" />
                     <marko-web-content-body

--- a/packages/global/utils/split-content-body.js
+++ b/packages/global/utils/split-content-body.js
@@ -1,8 +1,14 @@
 const cheerio = require('cheerio');
 
-module.exports = ({ body } = {}) => {
-  const $ = cheerio.load(body);
+module.exports = ({ body, contentBodyWithInjections } = {}) => {
+  // if ther is a script tag assume content has something special and prevent splitting.
+  // return everthing in part one to render.
+  var regexp = /<script+.*>+.*<\/script>/g;
+  if(body.match(regexp)) return { partOne: contentBodyWithInjections };
+
+
   // Suspecting halfway needs to be calculated like quarterway due to injected ads here
+  const $ = cheerio.load(contentBodyWithInjections);
   const likelyHalfwayElement = Math.floor($('div').children().length / 4);
   const part1Nodes = [];
   const part2Nodes = [];

--- a/packages/global/utils/split-content-body.js
+++ b/packages/global/utils/split-content-body.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 module.exports = ({ body, contentBodyWithInjections } = {}) => {
   // if ther is a script tag assume content has something special and prevent splitting.
   // return everthing in part one to render.
-  const regexp = /<script+.*>+.*<\/script>/g;
+  const regexp = /<script.*>.*<\/script>/g;
   if (body.match(regexp)) return { partOne: contentBodyWithInjections };
 
   // Suspecting halfway needs to be calculated like quarterway due to injected ads here

--- a/packages/global/utils/split-content-body.js
+++ b/packages/global/utils/split-content-body.js
@@ -3,9 +3,8 @@ const cheerio = require('cheerio');
 module.exports = ({ body, contentBodyWithInjections } = {}) => {
   // if ther is a script tag assume content has something special and prevent splitting.
   // return everthing in part one to render.
-  var regexp = /<script+.*>+.*<\/script>/g;
-  if(body.match(regexp)) return { partOne: contentBodyWithInjections };
-
+  const regexp = /<script+.*>+.*<\/script>/g;
+  if (body.match(regexp)) return { partOne: contentBodyWithInjections };
 
   // Suspecting halfway needs to be calculated like quarterway due to injected ads here
   const $ = cheerio.load(contentBodyWithInjections);


### PR DESCRIPTION
Assume that if a client is putting in a <script> in the body they are trying to do something special.  Return the whole body

### With Scripts:
<img width="1868" alt="Screenshot 2024-10-16 at 9 21 23 AM" src="https://github.com/user-attachments/assets/340837c4-f7d5-4b73-9de6-471287b8424c">


### Without
<img width="1951" alt="Screenshot 2024-10-16 at 9 21 36 AM" src="https://github.com/user-attachments/assets/23ff4803-d33c-4963-b835-ce90a014ec56">