### PR TITLE
Add ‘Videos’ block to homepage

### DIFF
--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -68,6 +68,13 @@ $ const { site } = out.global;
   </if>
 
   <@section>
+    <global-hero-card-block
+      query-params={ includeContentTypes: ["Video"] }
+      section={ name: "Videos", canonicalPath: "/videos"}
+    />
+  </@section>
+
+  <@section>
     <marko-web-identity-x-context|{ hasUser }|>
       <if(!hasUser)>
         <identity-x-newsletter-form-inline


### PR DESCRIPTION
<img width="969" alt="Screenshot 2025-01-17 at 10 58 29 AM" src="https://github.com/user-attachments/assets/f5d43ea0-aee2-4679-b274-2e1313e1c013" />
