### PR TITLE
Add header and view more to Videos block on homepage

### DIFF
--- a/sites/healthcarepackaging.com/server/styles/index.scss
+++ b/sites/healthcarepackaging.com/server/styles/index.scss
@@ -83,16 +83,6 @@ $theme-site-navbar-secondary-font-size: 16px !default;
 }
 
 .page {
-  &--website-section, &--content {
-    .hero-card {
-      &__header {
-        display: none;
-      }
-      &__description-wrapper {
-        display: none;
-      }
-    }
-  }
   &--website-section-33323 {
     .page-wrapper {
       &__section {


### PR DESCRIPTION
<img width="1355" alt="Screenshot 2025-01-22 at 3 06 00 PM" src="https://github.com/user-attachments/assets/5cd5b004-20af-4ef1-ace6-dca93a3ba798" />
