### PR TITLE
Correct routing for remaining 4 sites

### DIFF
--- a/sites/healthcarepackaging.com/server/routes/website-section.js
+++ b/sites/healthcarepackaging.com/server/routes/website-section.js
@@ -1,14 +1,13 @@
 const { withWebsiteSection } = require('@mindful-web/marko-web/middleware');
 const { asyncRoute } = require('@mindful-web/utils');
 const queryFragment = require('@mindful-web/marko-web-theme-monorail/graphql/fragments/website-section-page');
-const leadersFragment = require('@pmmi-media-group/package-global/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const events = require('@pmmi-media-group/package-global/templates/website-section/events');
 const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const collections = require('@pmmi-media-group/package-global/templates/website-section/collections');
+const directory = require('@pmmi-media-group/package-global/routes/directory');
 
 const section = require('../templates/website-section');
-const leaders = require('../templates/website-section/leaders');
 const news = require('../templates/website-section/news');
 
 module.exports = (app) => {
@@ -63,10 +62,28 @@ module.exports = (app) => {
     description: 'Industry experts talk medical packaging technologies, sustainability, and logistics, ranging from fill/finish, package design, automation, and temperature control.',
   })));
 
-  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
+  directory(app, {
+    rootAlias: 'company-categories-2024',
+    contentTypes: ['Company'],
+    assignedToWebsiteSectionIds: [
+      87193,
+      87205,
+      87206,
+      87207,
+      87208,
+      87218,
+      87219,
+      87220,
+      87221,
+      87222,
+      87230,
+      87231,
+      87279,
+      87280,
+      87293,
+      87294,
+    ],
+  });
 
   app.get('/:alias(news)', newsletterState(), withWebsiteSection({
     template: news,

--- a/sites/mundopmmi.com/server/routes/website-section.js
+++ b/sites/mundopmmi.com/server/routes/website-section.js
@@ -1,14 +1,13 @@
 const { withWebsiteSection } = require('@mindful-web/marko-web/middleware');
 const { asyncRoute } = require('@mindful-web/utils');
 const queryFragment = require('@mindful-web/marko-web-theme-monorail/graphql/fragments/website-section-page');
-const leadersFragment = require('@pmmi-media-group/package-global/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const events = require('@pmmi-media-group/package-global/templates/website-section/events');
 const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const collections = require('@pmmi-media-group/package-global/templates/website-section/collections');
+const directory = require('@pmmi-media-group/package-global/routes/directory');
 
 const section = require('../templates/website-section');
-const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
   app.get('/reciclaje-quimico', asyncRoute(async (_, res) => res.marko(collections, {
@@ -128,10 +127,30 @@ module.exports = (app) => {
     description: 'Perspectivas y análisis de líderes de opinión sobre tecnologías y tendencias de mercado en las industrias de envasado, procesamiento de alimentos y bebidas, y automatización.',
   })));
 
-  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
+  directory(app, {
+    rootAlias: 'company-categories-2025',
+    contentTypes: ['Company'],
+    assignedToWebsiteSectionIds: [
+      88983,
+      88981,
+      88995,
+      88982,
+      88984,
+      88980,
+      88987,
+      88992,
+      88991,
+      88986,
+      88988,
+      88989,
+      88990,
+      88994,
+      88993,
+      89082,
+      88996,
+      88985,
+    ],
+  });
 
   app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,

--- a/sites/oemmagazine.org/server/routes/website-section.js
+++ b/sites/oemmagazine.org/server/routes/website-section.js
@@ -1,15 +1,14 @@
 const { withWebsiteSection } = require('@mindful-web/marko-web/middleware');
 const { asyncRoute } = require('@mindful-web/utils');
 const queryFragment = require('@mindful-web/marko-web-theme-monorail/graphql/fragments/website-section-page');
-const leadersFragment = require('@pmmi-media-group/package-global/graphql/fragments/leaders-section');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const events = require('@pmmi-media-group/package-global/templates/website-section/events');
 const collections = require('@pmmi-media-group/package-global/templates/website-section/collections');
 const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const withTopStoriesBlock = require('@pmmi-media-group/package-global/templates/website-section/with-top-stories-block');
+const directory = require('@pmmi-media-group/package-global/routes/directory');
 
 const section = require('../templates/website-section');
-const leaders = require('../templates/website-section/leaders');
 
 module.exports = (app) => {
   app.get('/ai', asyncRoute(async (_, res) => res.marko(collections, {
@@ -69,10 +68,33 @@ module.exports = (app) => {
     description: '',
   })));
 
-  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
+  directory(app, {
+    rootAlias: 'company-categories-2024',
+    contentTypes: ['Company'],
+    assignedToWebsiteSectionIds: [
+      87209,
+      87210,
+      87211,
+      87212,
+      87213,
+      87214,
+      87215,
+      87216,
+      87217,
+      87223,
+      87224,
+      87225,
+      87226,
+      87227,
+      87228,
+      87229,
+      87295,
+      87296,
+      87297,
+      87298,
+      87299,
+    ],
+  });
 
   app.get('/:alias(WomenInPackaging)', newsletterState(), withWebsiteSection({
     template: withTopStoriesBlock,

--- a/sites/profoodworld.com/server/routes/website-section.js
+++ b/sites/profoodworld.com/server/routes/website-section.js
@@ -1,15 +1,14 @@
 const { withWebsiteSection } = require('@mindful-web/marko-web/middleware');
 const { asyncRoute } = require('@mindful-web/utils');
 const queryFragment = require('@mindful-web/marko-web-theme-monorail/graphql/fragments/website-section-page');
-const leadersFragment = require('@pmmi-media-group/package-global/graphql/fragments/leaders-section');
 const emergingBrandsFragment = require('@pmmi-media-group/package-global/graphql/fragments/emerging-brands-section-page');
 const { newsletterState } = require('@pmmi-media-group/package-global/middleware/newsletter-state');
 const webinars = require('@pmmi-media-group/package-global/templates/website-section/webinars');
 const events = require('@pmmi-media-group/package-global/templates/website-section/events');
 const collections = require('@pmmi-media-group/package-global/templates/website-section/collections');
 const superCategory = require('@pmmi-media-group/package-global/templates/website-section/super-category');
+const directory = require('@pmmi-media-group/package-global/routes/directory');
 const section = require('../templates/website-section');
-const leaders = require('../templates/website-section/leaders');
 const global250 = require('../templates/website-section/global-250');
 const global50 = require('../templates/website-section/global-50');
 
@@ -49,10 +48,15 @@ module.exports = (app) => {
     description: 'Industry expert insights on technologies, equipment, and software for food and beverage manufacturing.',
   })));
 
-  app.get('/:alias(leaders)', newsletterState(), withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
+  directory(app, {
+    rootAlias: 'company-categories-2024',
+    contentTypes: ['Company'],
+    assignedToWebsiteSectionIds: [
+      87194,
+      87281,
+      87300,
+    ],
+  });
 
   app.get('/:alias(emergingbrands)', newsletterState(), withWebsiteSection({
     template: section,


### PR DESCRIPTION
![Screenshot from 2025-02-05 11-03-19](https://github.com/user-attachments/assets/e3a140a4-a291-4531-83cf-f4a3912be4ca)
![Screenshot from 2025-02-05 11-04-43](https://github.com/user-attachments/assets/5c7774cb-9659-4cef-bd61-b41771277bd4)
![Screenshot from 2025-02-05 11-07-27](https://github.com/user-attachments/assets/c7568a2c-6f95-4cf3-b3ac-ffc032d5d607)
![Screenshot from 2025-02-05 11-11-17](https://github.com/user-attachments/assets/b9a1fdab-7105-4f99-bb0f-67c99ea8390a)
