### PR TITLE
Adjust PackWorld in content rotation ads to include 300x50

### DIFF
--- a/sites/packworld.com/config/gam.js
+++ b/sites/packworld.com/config/gam.js
@@ -12,6 +12,25 @@ config.setAliasAdUnits('default', [
   { name: 'wallpaper-right', templateName: 'WALLPAPER', path: 'wallpaper-right' },
 ]);
 
+config.setTemplate('INLINE-CONTENT', {
+  size: [[300, 250], [300, 50]],
+  sizeMapping: [
+    { viewport: [0, 0], size: [[300, 250], [300, 50]] },
+  ],
+}).setTemplate('INLINE-CONTENT-MOBILE', {
+  size: [[300, 250], [300, 50]],
+  sizeMapping: [
+    { viewport: [980, 0], size: [] },
+    { viewport: [320, 0], size: [[300, 250], [300, 50]] },
+  ],
+}).setTemplate('INLINE-CONTENT-DESKTOP', {
+  size: [[300, 250], [300, 50]],
+  sizeMapping: [
+    { viewport: [980, 0], size: [[300, 250], [300, 50]] },
+    { viewport: [0, 0], size: [] },
+  ],
+});
+
 const aliases = [
   { alias: 'sustainable-packaging' },
   { alias: 'sustainable-packaging/recycling', prefix: 'recycling' },


### PR DESCRIPTION
https://trello.com/c/Bn40SxVE/1079-packworld-add-300x50-size-to-the-in-content-rotation-ad-unit

<img width="1501" alt="Screenshot 2025-05-09 at 1 51 38 PM" src="https://github.com/user-attachments/assets/3c8cae71-ad02-487f-8967-f455728043a3" />
