### PR TITLE
Replace ‘Sustainablility’ with ‘Workforce’ on homepage

### DIFF
--- a/sites/profoodworld.com/server/templates/index.marko
+++ b/sites/profoodworld.com/server/templates/index.marko
@@ -27,7 +27,7 @@ $ const { site } = out.global;
   </@section>
 
   <@section>
-    <global-published-content-list-deck-block section-ids=[63672, 33413, 67020] />
+    <global-published-content-list-deck-block section-ids=[87612, 33413, 67020] />
   </@section>
 
   <@section|{ aliases }|>


### PR DESCRIPTION
<img width="1128" height="883" alt="Screenshot 2025-07-30 at 9 40 04 AM" src="https://github.com/user-attachments/assets/8151da65-b9c5-4505-aa61-48d0f56670d1" />
