### PR TITLE
Include leaderboard ad name on Article type ad injections

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -249,6 +249,8 @@ $ const shouldInjectAds = ["article", "blog", "news", "podcast", "press-release"
                     blockName,
                     selector: bodyId,
                     preventHTMLInjection: !shouldInjectAds,
+                    desktopLeaderboardAdName: "top-inline-content-desktop",
+                    mobileLeaderboardAdName: "top-inline-content-mobile",
                     $global
                   });
                   $ const { partOne, partTwo } = splitContentBody({ body: content.body, contentBodyWithInjections });


### PR DESCRIPTION
Article without story continues button:
<img width="2560" height="1440" alt="Screenshot from 2025-08-11 11-28-38" src="https://github.com/user-attachments/assets/b3ac184b-f32a-4d28-a20d-a7e136633c51" />
Product (no change):
<img width="2560" height="1440" alt="Screenshot from 2025-08-11 11-29-22" src="https://github.com/user-attachments/assets/b3927d89-7801-469c-85c9-b37a1b619021" />
Article with story continues button:
<img width="2560" height="1440" alt="Screenshot from 2025-08-11 11-29-58" src="https://github.com/user-attachments/assets/74892c7f-1886-4d91-b501-251d424071aa" />
