### PR TITLE
Exclude ‘Webinar’ label from homepages & published content areas

### DIFF
--- a/packages/global/components/blocks/published-content-list.marko
+++ b/packages/global/components/blocks/published-content-list.marko
@@ -18,7 +18,7 @@ $ const params = {
     includeContentTypes: ["Document"],
     excludeContentTypes: ["Contact", "Company", "Promotion"]
   }),
-  excludeLabels: ["Quiz", "Supplier Submitted, Webinar"],
+  excludeLabels: ["Quiz", "Supplier Submitted", "Webinar"],
   sectionBubbling: true,
   queryFragment
 }

--- a/packages/global/components/blocks/published-content-list.marko
+++ b/packages/global/components/blocks/published-content-list.marko
@@ -18,7 +18,7 @@ $ const params = {
     includeContentTypes: ["Document"],
     excludeContentTypes: ["Contact", "Company", "Promotion"]
   }),
-  excludeLabels: ["Quiz", "Supplier Submitted"],
+  excludeLabels: ["Quiz", "Supplier Submitted, Webinar"],
   sectionBubbling: true,
   queryFragment
 }

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -26,7 +26,7 @@ $ const sections = getAsArray(input, "sections");
       lazyload=false
       query-params={
         optionName: "Pinned",
-        excludeLabels: ["Supplier Submitted"]
+        excludeLabels: ["Supplier Submitted, Webinar"]
       }
     />
   </@section>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -26,7 +26,7 @@ $ const sections = getAsArray(input, "sections");
       lazyload=false
       query-params={
         optionName: "Pinned",
-        excludeLabels: ["Supplier Submitted, Webinar"]
+        excludeLabels: ["Supplier Submitted", "Webinar"]
       }
     />
   </@section>

--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -60,7 +60,7 @@ $ const { site } = out.global;
   <@section>
     <theme-section-feed-block alias="home">
       <@before><div class="node-list__header" style="padding: 0px">More from Healthcare Packaging</div></@before>
-      <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted, Webinar"] />
+      <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted", "Webinar"] />
     </theme-section-feed-block>
   </@section>
 

--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -60,7 +60,7 @@ $ const { site } = out.global;
   <@section>
     <theme-section-feed-block alias="home">
       <@before><div class="node-list__header" style="padding: 0px">More from Healthcare Packaging</div></@before>
-      <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted"] />
+      <@query-params limit=12 skip=1 exclude-labels=["Supplier Submitted, Webinar"] />
     </theme-section-feed-block>
   </@section>
 


### PR DESCRIPTION
Same as ‘Supplier Submitted’ label

WITH WEBINAR LABEL:
<img width="1577" height="962" alt="Screenshot 2025-09-15 at 1 37 03 PM" src="https://github.com/user-attachments/assets/1496af3e-e885-46f9-bc7e-3b7f8c5d9f4e" />

WITHOUT WEBINAR LABEL:
<img width="1331" height="893" alt="Screenshot 2025-09-15 at 1 37 37 PM" src="https://github.com/user-attachments/assets/0b9d2fdd-7729-4150-95b9-992f75f1d854" />
